### PR TITLE
Import and export of the sketch

### DIFF
--- a/src-tauri/src/app/state/editor/_state_editor_session.rs
+++ b/src-tauri/src/app/state/editor/_state_editor_session.rs
@@ -4,7 +4,7 @@ use crate::app::state::editor::TabBarState;
 use crate::app::state::{Consumed, Session, SessionHelper, SessionState};
 use crate::app::{AeonError, DynError};
 use crate::debug;
-use crate::sketchbook::sketch::Sketch;
+use crate::sketchbook::Sketch;
 
 /// The state of one editor session.
 ///

--- a/src-tauri/src/sketchbook/_sketch/_impl_sketch.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_sketch.rs
@@ -1,0 +1,80 @@
+use crate::sketchbook::data_structs::SketchData;
+use crate::sketchbook::model::ModelState;
+use crate::sketchbook::observations::{Dataset, ObservationManager};
+use crate::sketchbook::properties::{DynProperty, PropertyManager, StatProperty};
+use crate::sketchbook::Sketch;
+
+impl Sketch {
+    /// Parse and validate all components of `Sketch` from a corresponding `SketchData` instance.
+    pub fn components_from_sketch_data(
+        sketch_data: &SketchData,
+    ) -> Result<(ModelState, ObservationManager, PropertyManager), String> {
+        let datasets = sketch_data
+            .datasets
+            .iter()
+            .map(|d| d.to_dataset())
+            .collect::<Result<Vec<Dataset>, String>>()?;
+        let dyn_properties = sketch_data
+            .dyn_properties
+            .iter()
+            .map(|prop_data| prop_data.to_property())
+            .collect::<Result<Vec<DynProperty>, String>>()?;
+        let stat_properties = sketch_data
+            .stat_properties
+            .iter()
+            .map(|prop_data| prop_data.to_property())
+            .collect::<Result<Vec<StatProperty>, String>>()?;
+
+        let model = ModelState::new_from_model_data(&sketch_data.model)?;
+        let obs_manager = ObservationManager::from_datasets(
+            sketch_data
+                .datasets
+                .iter()
+                .map(|d| d.id.as_str())
+                .zip(datasets)
+                .collect(),
+        )?;
+        let prop_manager = PropertyManager::new_from_properties(
+            sketch_data
+                .dyn_properties
+                .iter()
+                .map(|d| d.id.as_str())
+                .zip(dyn_properties)
+                .collect(),
+            sketch_data
+                .dyn_properties
+                .iter()
+                .map(|d| d.id.as_str())
+                .zip(stat_properties)
+                .collect(),
+        )?;
+        Ok((model, obs_manager, prop_manager))
+    }
+
+    /// Create a new `Sketch` instance given a corresponding `SketchData` object.
+    pub fn new_from_sketch_data(sketch_data: &SketchData) -> Result<Sketch, String> {
+        let (model, obs_manager, prop_manager) = Self::components_from_sketch_data(sketch_data)?;
+        Ok(Sketch {
+            model,
+            observations: obs_manager,
+            properties: prop_manager,
+        })
+    }
+
+    /// Modify this `Sketch` instance by loading all its components from a corresponding
+    /// `SketchData` instance. The original sketch information is forgotten.
+    pub fn modify_from_sketch_data(&mut self, sketch_data: &SketchData) -> Result<(), String> {
+        let (model, obs_manager, prop_manager) = Self::components_from_sketch_data(sketch_data)?;
+        self.model = model;
+        self.observations = obs_manager;
+        self.properties = prop_manager;
+        Ok(())
+    }
+
+    /// Modify this `Sketch` instance to a default (empty) settings.
+    pub fn set_to_empty(&mut self) {
+        self.model = ModelState::default();
+        self.observations = ObservationManager::default();
+        self.properties = PropertyManager::default();
+    }
+}

--- a/src-tauri/src/sketchbook/_sketch/mod.rs
+++ b/src-tauri/src/sketchbook/_sketch/mod.rs
@@ -1,0 +1,36 @@
+use crate::sketchbook::model::ModelState;
+use crate::sketchbook::observations::ObservationManager;
+use crate::sketchbook::properties::PropertyManager;
+use crate::sketchbook::{JsonSerde, Manager};
+use serde::{Deserialize, Serialize};
+
+/// **(internal)** Implementation of event-based API for the [SessionState] trait.
+mod _impl_session_state;
+/// **(internal)** Utility methods for `Sketch`.
+mod _impl_sketch;
+
+/// Object encompassing all of the individual modules of the Boolean network sketch.
+///
+/// Most of the actual functionality is implemented by the modules themselves, `Sketch`
+/// currently only distributes events and handles situations when cooperation between
+/// modules is needed.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Sketch {
+    model: ModelState,
+    observations: ObservationManager,
+    properties: PropertyManager,
+}
+
+impl<'de> JsonSerde<'de> for Sketch {}
+impl Manager for Sketch {}
+
+impl Default for Sketch {
+    /// Default empty sketch.
+    fn default() -> Sketch {
+        Sketch {
+            model: ModelState::default(),
+            observations: ObservationManager::default(),
+            properties: PropertyManager::default(),
+        }
+    }
+}

--- a/src-tauri/src/sketchbook/_tests_events/_model.rs
+++ b/src-tauri/src/sketchbook/_tests_events/_model.rs
@@ -57,7 +57,7 @@ fn test_remove_var_complex() {
     model.update_position(layout_id, &var_a, 1., 1.).unwrap();
 
     // expected result
-    let mut model_expected = ModelState::new();
+    let mut model_expected = ModelState::new_empty();
     model_expected.add_var_by_str("b", "b").unwrap();
     model_expected.add_regulation_by_str("b -> b").unwrap();
 
@@ -136,7 +136,7 @@ fn test_set_update_fn() {
 #[test]
 /// Test that several kinds of invalid operations fail successfully.
 fn test_invalid_var_events() {
-    let mut model = ModelState::new();
+    let mut model = ModelState::new_empty();
     let var_id = model.generate_var_id("a");
     model.add_var(var_id.clone(), "a-name").unwrap();
     let model_orig = model.clone();
@@ -232,7 +232,7 @@ fn test_remove_reg() {
 #[test]
 /// Test changing position of a layout node via event.
 fn test_change_position() {
-    let mut model = ModelState::new();
+    let mut model = ModelState::new_empty();
     let layout_id = ModelState::get_default_layout_id();
     let var_id = model.generate_var_id("a");
     model.add_var(var_id.clone(), "a_name").unwrap();
@@ -253,9 +253,9 @@ fn test_change_position() {
 #[test]
 /// Test changing monotonicity and essentiality of uninterpreted function's argument via event.
 fn test_change_fn_arg_monotonicity_essentiality() {
-    let mut model = ModelState::new();
+    let mut model = ModelState::new_empty();
     let f = model.generate_uninterpreted_fn_id("f");
-    model.add_new_uninterpreted_fn(f.clone(), "f", 2).unwrap();
+    model.add_empty_uninterpreted_fn(f.clone(), "f", 2).unwrap();
     let model_orig = model.clone();
 
     // test event for changing uninterpreted fn's monotonicity
@@ -284,9 +284,9 @@ fn test_change_fn_arg_monotonicity_essentiality() {
 #[test]
 /// Test changing uninterpreted function's expression via event.
 fn test_change_fn_expression() {
-    let mut model = ModelState::new();
+    let mut model = ModelState::new_empty();
     let f = model.generate_uninterpreted_fn_id("f");
-    model.add_new_uninterpreted_fn(f.clone(), "f", 2).unwrap();
+    model.add_empty_uninterpreted_fn(f.clone(), "f", 2).unwrap();
     let model_orig = model.clone();
 
     // test event for changing uninterpreted fn's expression

--- a/src-tauri/src/sketchbook/data_structs/_layout_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_layout_data.rs
@@ -33,7 +33,7 @@ impl<'de> JsonSerde<'de> for LayoutData {}
 impl<'de> JsonSerde<'de> for LayoutMetaData {}
 
 impl LayoutData {
-    /// Create new `LayoutData` object given a `layout` and its id.
+    /// Create new `LayoutData` instance given a `layout` and its id.
     pub fn from_layout(layout_id: &LayoutId, layout: &Layout) -> LayoutData {
         let nodes = layout
             .layout_nodes()
@@ -45,10 +45,20 @@ impl LayoutData {
             nodes,
         }
     }
+
+    /// Extract new `Layout` instance from this data.
+    pub fn to_layout(&self) -> Result<Layout, String> {
+        let var_node_pairs = self
+            .nodes
+            .iter()
+            .map(|node_data| (node_data.variable.as_str(), node_data.to_node()))
+            .collect();
+        Layout::new(&self.name, var_node_pairs)
+    }
 }
 
 impl LayoutMetaData {
-    /// Create new `LayoutMetaData` object given a layout's name and id string slices.
+    /// Create new `LayoutMetaData` instance given a layout's name and id string slices.
     pub fn new(layout_id: &str, layout_name: &str) -> LayoutMetaData {
         LayoutMetaData {
             id: layout_id.to_string(),
@@ -56,7 +66,7 @@ impl LayoutMetaData {
         }
     }
 
-    /// Create new `LayoutMetaData` object given a `layout` and its id.
+    /// Create new `LayoutMetaData` instance given a `layout` and its id.
     pub fn from_layout(layout_id: &LayoutId, layout: &Layout) -> LayoutMetaData {
         LayoutMetaData::new(layout_id.as_str(), layout.get_layout_name())
     }

--- a/src-tauri/src/sketchbook/data_structs/_layout_node_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_layout_node_data.rs
@@ -22,6 +22,7 @@ pub struct LayoutNodeData {
 impl<'de> JsonSerde<'de> for LayoutNodeData {}
 
 impl LayoutNodeData {
+    /// Create new `LayoutNodeData` instance given a node's layout ID, variable ID, and coordinates.
     pub fn new(layout_id: &str, var_id: &str, px: f32, py: f32) -> LayoutNodeData {
         LayoutNodeData {
             layout: layout_id.to_string(),
@@ -31,6 +32,8 @@ impl LayoutNodeData {
         }
     }
 
+    /// Create new `LayoutNodeData` instance given a node's layout ID, variable ID,
+    /// and corresponding `LayoutNode`.
     pub fn from_node(layout_id: &LayoutId, var_id: &VarId, node: &LayoutNode) -> LayoutNodeData {
         LayoutNodeData::new(
             layout_id.as_str(),
@@ -38,5 +41,10 @@ impl LayoutNodeData {
             node.get_px(),
             node.get_py(),
         )
+    }
+
+    /// Extract new `LayoutNode` instance from this data.
+    pub fn to_node(&self) -> LayoutNode {
+        LayoutNode::new(self.px, self.py)
     }
 }

--- a/src-tauri/src/sketchbook/data_structs/_model_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_model_data.rs
@@ -18,7 +18,7 @@ impl<'de> JsonSerde<'de> for ModelData {}
 
 impl ModelData {
     /// Create new `SketchData` instance given a reference to a model manager instance.
-    pub fn new(model: &ModelState) -> ModelData {
+    pub fn from_model(model: &ModelState) -> ModelData {
         let mut variables: Vec<_> = model
             .variables()
             .map(|(id, v)| VariableData::from_var(id, v, model.get_update_fn(id).unwrap()))

--- a/src-tauri/src/sketchbook/data_structs/_observation_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_observation_data.rs
@@ -18,7 +18,7 @@ pub struct ObservationData {
 impl<'de> JsonSerde<'de> for ObservationData {}
 
 impl ObservationData {
-    /// Create new `ObservationData` object given `id` and values string slices.
+    /// Create new `ObservationData` instance given `id` and values string slices.
     pub fn new(obs_id: &str, dataset_id: &str, values: &str) -> ObservationData {
         ObservationData {
             id: obs_id.to_string(),
@@ -27,7 +27,7 @@ impl ObservationData {
         }
     }
 
-    /// Create new `ObservationData` object given a reference to a observation, and ID of
+    /// Create new `ObservationData` instance given a reference to a observation, and ID of
     /// its dataset.
     pub fn from_obs(obs: &Observation, dataset_id: &DatasetId) -> ObservationData {
         ObservationData::new(

--- a/src-tauri/src/sketchbook/data_structs/_property_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_property_data.rs
@@ -1,5 +1,5 @@
-use crate::sketchbook::ids::DynPropertyId;
-use crate::sketchbook::properties::DynProperty;
+use crate::sketchbook::ids::{DynPropertyId, StatPropertyId};
+use crate::sketchbook::properties::{DynProperty, StatProperty};
 use crate::sketchbook::JsonSerde;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +15,7 @@ pub struct DynPropertyData {
     pub formula: String,
 }
 
-/// Structure for sending data about dynamic properties to the frontend.
+/// Structure for sending data about static properties to the frontend.
 ///
 /// Some fields simplified compared to original typesafe versions (e.g., pure `Strings` are used
 /// instead of more complex typesafe structs) to allow for easier (de)serialization.
@@ -24,13 +24,14 @@ pub struct DynPropertyData {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatPropertyData {
     pub id: String,
+    pub formula: String,
 }
 
 impl<'de> JsonSerde<'de> for DynPropertyData {}
 impl<'de> JsonSerde<'de> for StatPropertyData {}
 
 impl DynPropertyData {
-    /// Create new `DynPropertyData` object given a properties `id` and formula.
+    /// Create new `DynPropertyData` object given a properties `id` and `formula`.
     pub fn new(id: &str, formula: &str) -> DynPropertyData {
         DynPropertyData {
             id: id.to_string(),
@@ -42,11 +43,29 @@ impl DynPropertyData {
     pub fn from_property(id: &DynPropertyId, property: &DynProperty) -> DynPropertyData {
         DynPropertyData::new(id.as_str(), property.get_formula())
     }
+
+    /// Extract the corresponding `DynProperty` instance from this `DynPropertyData`.
+    pub fn to_property(&self) -> Result<DynProperty, String> {
+        DynProperty::try_from_str(&self.formula)
+    }
 }
 
 impl StatPropertyData {
-    /// Create new `StatPropertyData` object given a properties `id`.
-    pub fn new(id: &str) -> StatPropertyData {
-        StatPropertyData { id: id.to_string() }
+    /// Create new `StatPropertyData` object given a properties `id` and `formula`.
+    pub fn new(id: &str, formula: &str) -> StatPropertyData {
+        StatPropertyData {
+            id: id.to_string(),
+            formula: formula.to_string(),
+        }
+    }
+
+    /// Create new `StatPropertyData` object given a reference to a property and its `id`.
+    pub fn from_property(id: &StatPropertyId, property: &StatProperty) -> StatPropertyData {
+        StatPropertyData::new(id.as_str(), property.get_formula())
+    }
+
+    /// Extract the corresponding `StatProperty` instance from this `StatPropertyData`.
+    pub fn to_property(&self) -> Result<StatProperty, String> {
+        StatProperty::try_from_str(&self.formula)
     }
 }

--- a/src-tauri/src/sketchbook/data_structs/_regulation_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_regulation_data.rs
@@ -1,3 +1,4 @@
+use crate::sketchbook::ids::VarId;
 use crate::sketchbook::model::{Essentiality, Monotonicity, Regulation};
 use crate::sketchbook::JsonSerde;
 use serde::{Deserialize, Serialize};
@@ -46,5 +47,15 @@ impl RegulationData {
     pub fn try_from_reg_str(regulation_str: &str) -> Result<RegulationData, String> {
         let regulation = Regulation::try_from_string(regulation_str)?;
         Ok(RegulationData::from_reg(&regulation))
+    }
+
+    /// Extract new `Regulation` instance from this data.
+    pub fn to_reg(&self) -> Result<Regulation, String> {
+        Ok(Regulation::new(
+            VarId::new(&self.regulator)?,
+            VarId::new(&self.target)?,
+            self.essential,
+            self.sign,
+        ))
     }
 }

--- a/src-tauri/src/sketchbook/data_structs/_sketch_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_sketch_data.rs
@@ -33,11 +33,11 @@ impl SketchData {
             .collect();
         let stat_properties = properties
             .stat_props()
-            .map(|(p_id, _)| StatPropertyData::new(p_id.as_str()))
+            .map(|(p_id, p)| StatPropertyData::from_property(p_id, p))
             .collect();
 
         SketchData {
-            model: ModelData::new(model),
+            model: ModelData::from_model(model),
             datasets,
             dyn_properties,
             stat_properties,

--- a/src-tauri/src/sketchbook/data_structs/_uninterpreted_fn_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_uninterpreted_fn_data.rs
@@ -1,5 +1,7 @@
 use crate::sketchbook::ids::UninterpretedFnId;
-use crate::sketchbook::model::{Essentiality, FnArgument, Monotonicity, UninterpretedFn};
+use crate::sketchbook::model::{
+    Essentiality, FnArgument, ModelState, Monotonicity, UninterpretedFn,
+};
 use crate::sketchbook::JsonSerde;
 use serde::{Deserialize, Serialize};
 
@@ -49,6 +51,25 @@ impl UninterpretedFnData {
             uninterpreted_fn.get_name(),
             arguments,
             uninterpreted_fn.get_fn_expression(),
+        )
+    }
+
+    /// Extract new `UninterpretedFn` instance from this data (if the function's expression
+    /// is valid).
+    ///
+    /// Model is given for validity check during parsing the function's expression.
+    pub fn to_uninterpreted_fn(&self, model: &ModelState) -> Result<UninterpretedFn, String> {
+        let arguments = self
+            .arguments
+            .iter()
+            .map(|(m, e)| FnArgument::new(*e, *m))
+            .collect();
+        UninterpretedFn::new(
+            &self.name,
+            &self.expression,
+            arguments,
+            model,
+            &model.get_uninterpreted_fn_id(&self.id)?,
         )
     }
 }

--- a/src-tauri/src/sketchbook/data_structs/_variable_data.rs
+++ b/src-tauri/src/sketchbook/data_structs/_variable_data.rs
@@ -36,4 +36,9 @@ impl VariableData {
             update_fn.get_fn_expression(),
         )
     }
+
+    /// Extract new `Variable` instance from this data.
+    pub fn to_var(&self) -> Result<Variable, String> {
+        Variable::new(self.name.as_str())
+    }
 }

--- a/src-tauri/src/sketchbook/ids.rs
+++ b/src-tauri/src/sketchbook/ids.rs
@@ -13,7 +13,7 @@ lazy_static! {
 
 /// **(internal)** A base class to derive type-safe identifiers from (using a macro below).
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
-struct BaseId {
+pub struct BaseId {
     id: String,
 }
 

--- a/src-tauri/src/sketchbook/layout/_layout/_impl_layout.rs
+++ b/src-tauri/src/sketchbook/layout/_layout/_impl_layout.rs
@@ -6,19 +6,33 @@ use std::collections::HashMap;
 /// Methods for safely constructing or mutating instances of `Layout`.
 impl Layout {
     /// Create new empty `Layout` (i.e., with no nodes) with a given name.
-    pub fn new_empty(name_str: &str) -> Result<Layout, String> {
-        assert_name_valid(name_str)?;
+    pub fn new_empty(name: &str) -> Result<Layout, String> {
+        assert_name_valid(name)?;
         Ok(Layout {
-            name: name_str.to_string(),
+            name: name.to_string(),
             nodes: HashMap::new(),
         })
     }
 
+    /// Create new `Layout` with a given name and nodes.
+    pub fn new(name: &str, var_node_pairs: Vec<(&str, LayoutNode)>) -> Result<Layout, String> {
+        // before making any changes, check that all IDs are actually valid and unique
+        let var_ids: Vec<&str> = var_node_pairs.iter().map(|pair| pair.0).collect();
+        assert_ids_unique(&var_ids)?;
+
+        // now we can safely add them
+        let mut layout = Layout::new_empty(name)?;
+        for (var_id, node) in var_node_pairs {
+            layout.add_node(VarId::new(var_id)?, node)?;
+        }
+        Ok(layout)
+    }
+
     /// Create new `Layout` with a given name, that is a direct copy of another existing
     /// valid `template_layout`.
-    pub fn new_from_another_copy(name_str: &str, template_layout: &Layout) -> Layout {
+    pub fn new_from_another_copy(name: &str, template_layout: &Layout) -> Layout {
         Layout {
-            name: name_str.to_string(),
+            name: name.to_string(),
             nodes: template_layout.nodes.clone(),
         }
     }
@@ -27,24 +41,32 @@ impl Layout {
     /// all of the nodes will be located at a default position.
     ///
     /// Returns `Error` if given ids contain duplicates.
-    pub fn new_from_vars_default(
-        name_str: &str,
-        variable_ids: Vec<VarId>,
-    ) -> Result<Layout, String> {
+    pub fn new_from_vars_default(name: &str, variables: Vec<VarId>) -> Result<Layout, String> {
         // before making any changes, check that all IDs are actually valid and unique
-        assert_ids_unique(&variable_ids)?;
+        assert_ids_unique(&variables)?;
         // now we can safely add them
-        let mut layout = Layout::new_empty(name_str)?;
-        for var_id in variable_ids {
+        let mut layout = Layout::new_empty(name)?;
+        for var_id in variables {
             layout.add_default_node(var_id.clone())?;
         }
         Ok(layout)
     }
 
     /// Rename this `Layout`.
-    pub fn set_layout_name(&mut self, name_str: &str) -> Result<(), String> {
-        assert_name_valid(name_str)?;
-        self.name = name_str.to_string();
+    pub fn set_layout_name(&mut self, name: &str) -> Result<(), String> {
+        assert_name_valid(name)?;
+        self.name = name.to_string();
+        Ok(())
+    }
+
+    /// Add a new (pre-generated) node.
+    ///
+    /// You must ensure that the `variable` is valid before adding it to the layout.
+    ///
+    /// Returns `Err` if there already is a node for this variable.
+    pub fn add_node(&mut self, var: VarId, node: LayoutNode) -> Result<(), String> {
+        self.assert_no_variable(&var)?;
+        self.nodes.insert(var, node);
         Ok(())
     }
 
@@ -54,11 +76,9 @@ impl Layout {
     /// You must ensure that the `variable` is valid before adding it to the layout.
     ///
     /// Returns `Err` if there already is a node for this variable.
-    pub fn add_node(&mut self, variable: VarId, p_x: f32, p_y: f32) -> Result<(), String> {
-        if self.nodes.contains_key(&variable) {
-            return Err(format!("Layout data for {variable} already exist."));
-        }
-        self.nodes.insert(variable, LayoutNode::new(p_x, p_y));
+    pub fn add_node_by_coords(&mut self, var: VarId, p_x: f32, p_y: f32) -> Result<(), String> {
+        self.assert_no_variable(&var)?;
+        self.nodes.insert(var, LayoutNode::new(p_x, p_y));
         Ok(())
     }
 
@@ -68,9 +88,7 @@ impl Layout {
     ///
     /// Returns `Err` if there already is a node for this variable.
     pub fn add_default_node(&mut self, variable: VarId) -> Result<(), String> {
-        if self.nodes.contains_key(&variable) {
-            return Err(format!("Layout data for {variable} already exist."));
-        }
+        self.assert_no_variable(&variable)?;
         self.nodes.insert(variable, LayoutNode::default());
         Ok(())
     }
@@ -84,11 +102,10 @@ impl Layout {
         new_x: f32,
         new_y: f32,
     ) -> Result<(), String> {
+        self.assert_valid_variable(variable)?;
         self.nodes
             .get_mut(variable)
-            .ok_or(format!(
-                "Variable {variable} doesn't have a layout information to remove."
-            ))?
+            .unwrap()
             .change_position(new_x, new_y);
         Ok(())
     }
@@ -97,24 +114,39 @@ impl Layout {
     ///
     /// Return `Err` if variable did not have a corresponding node in this layout.
     pub fn remove_node(&mut self, variable: &VarId) -> Result<(), String> {
-        if self.nodes.remove(variable).is_none() {
-            return Err(format!(
-                "Variable {variable} doesn't have a layout information to remove."
-            ));
-        }
+        self.assert_valid_variable(variable)?;
+        self.nodes.remove(variable);
         Ok(())
     }
 
     /// Change id of a variable with `original_id` to `new_id`.
     pub fn change_node_id(&mut self, original_id: &VarId, new_id: VarId) -> Result<(), String> {
+        self.assert_valid_variable(original_id)?;
         if let Some(node_layout) = self.nodes.remove(original_id) {
             self.nodes.insert(new_id.clone(), node_layout);
-        } else {
-            return Err(format!(
-                "Variable {original_id} doesn't have a layout information to remove."
-            ));
         }
         Ok(())
+    }
+}
+
+/// Utility methods to assert (non-)existence of nodes in the layout.
+impl Layout {
+    /// **(internal)** Utility method to ensure there is no node for the variable with given Id yet.
+    fn assert_no_variable(&self, var_id: &VarId) -> Result<(), String> {
+        if self.nodes.contains_key(var_id) {
+            Err(format!("Layout node for {var_id} already exists."))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// **(internal)** Utility method to ensure there is a node for a variable with given Id.
+    fn assert_valid_variable(&self, var_id: &VarId) -> Result<(), String> {
+        if self.nodes.contains_key(var_id) {
+            Ok(())
+        } else {
+            Err(format!("Layout node for {var_id} does not exist."))
+        }
     }
 }
 
@@ -172,8 +204,8 @@ mod tests {
         // add node v1, node v2, and try adding v1 again (should fail)
         layout.add_default_node(var_id1.clone()).unwrap();
         assert_eq!(layout.get_node(&var_id1).unwrap(), &default_node);
-        layout.add_node(var_id2.clone(), 1., 2.).unwrap();
-        assert!(layout.add_node(var_id1_again, 1., 2.).is_err());
+        layout.add_node_by_coords(var_id2.clone(), 1., 2.).unwrap();
+        assert!(layout.add_node_by_coords(var_id1_again, 1., 2.).is_err());
         assert_eq!(layout.get_num_nodes(), 2);
 
         // change position of node v1, and try changing position of node thats not in the network

--- a/src-tauri/src/sketchbook/layout/_layout/_impl_layout_serde.rs
+++ b/src-tauri/src/sketchbook/layout/_layout/_impl_layout_serde.rs
@@ -121,7 +121,9 @@ mod tests {
     #[test]
     fn test_layout_serde() {
         let mut layout = Layout::new_empty("layout_name").unwrap();
-        layout.add_node(VarId::new("v1").unwrap(), 1., 1.).unwrap();
+        layout
+            .add_node_by_coords(VarId::new("v1").unwrap(), 1., 1.)
+            .unwrap();
 
         // Serialization
         let layout_serialized = serde_json::to_string(&layout).unwrap();

--- a/src-tauri/src/sketchbook/layout/_layout/mod.rs
+++ b/src-tauri/src/sketchbook/layout/_layout/mod.rs
@@ -1,5 +1,6 @@
 use crate::sketchbook::ids::VarId;
 use crate::sketchbook::layout::LayoutNode;
+use crate::sketchbook::Manager;
 use std::collections::HashMap;
 use std::fmt::{Display, Error, Formatter};
 use std::str::FromStr;
@@ -16,6 +17,8 @@ pub struct Layout {
     name: String,
     nodes: HashMap<VarId, LayoutNode>,
 }
+
+impl Manager for Layout {}
 
 impl Display for Layout {
     /// Use json serialization to convert `Layout` to string.

--- a/src-tauri/src/sketchbook/model/_function_tree.rs
+++ b/src-tauri/src/sketchbook/model/_function_tree.rs
@@ -321,7 +321,7 @@ mod tests {
     #[test]
     /// Test parsing of a valid uninterpreted function's expression.
     fn test_valid_uninterpreted_fn() {
-        let mut model = ModelState::new();
+        let mut model = ModelState::new_empty();
         let arity = 2;
         model.add_uninterpreted_fn_by_str("f", "f", arity).unwrap();
         model.add_uninterpreted_fn_by_str("g", "g", arity).unwrap();

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_convert_reg_graph.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_convert_reg_graph.rs
@@ -50,7 +50,7 @@ impl ModelState {
     ///
     /// Note that only the default layout (all nodes at 0,0) is created for the `ModelState`.
     pub fn from_reg_graph(reg_graph: RegulatoryGraph) -> Result<ModelState, String> {
-        let mut model = ModelState::new();
+        let mut model = ModelState::new_empty();
 
         // variables
         for v in reg_graph.variables() {

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_id_generating.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_id_generating.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_layout_id_generating() {
-        let mut model = ModelState::new();
+        let mut model = ModelState::new_empty();
         let layout_id = LayoutId::new("l_0").unwrap();
         let default_layout_id = ModelState::get_default_layout_id();
         model.add_layout_simple(layout_id, "name").unwrap();

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_serde.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_serde.rs
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn test_model_state_serde() {
         // test on very simple `ModelState` with one var and no regulations
-        let mut model = ModelState::new();
+        let mut model = ModelState::new_empty();
         let var_id = VarId::new("a").unwrap();
         model.add_var(var_id, "a").unwrap();
 

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_refresh_events.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_refresh_events.rs
@@ -12,7 +12,7 @@ use crate::sketchbook::JsonSerde;
 impl ModelState {
     /// Get a whole model.
     pub(super) fn refresh_whole_model(&self, full_path: &[String]) -> Result<Event, DynError> {
-        let model_data = ModelData::new(self);
+        let model_data = ModelData::from_model(self);
         Ok(Event {
             path: full_path.to_vec(),
             payload: Some(model_data.to_json_str()),

--- a/src-tauri/src/sketchbook/model/_model_state/mod.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/mod.rs
@@ -41,6 +41,6 @@ impl Default for ModelState {
     /// Default model object with no Variables, Uninterpreted Functions, or Regulations yet.
     /// It contains a single empty default Layout.
     fn default() -> ModelState {
-        ModelState::new()
+        ModelState::new_empty()
     }
 }

--- a/src-tauri/src/sketchbook/model/_uninterpreted_fn.rs
+++ b/src-tauri/src/sketchbook/model/_uninterpreted_fn.rs
@@ -30,6 +30,23 @@ impl UninterpretedFn {
         })
     }
 
+    /// Create new `UninterpretedFn` instance given its components.
+    /// Model and ID are used for validity check during argument parsing.
+    pub fn new(
+        name: &str,
+        expression: &str,
+        arguments: Vec<FnArgument>,
+        model: &ModelState,
+        own_id: &UninterpretedFnId,
+    ) -> Result<UninterpretedFn, String> {
+        assert_name_valid(name)?;
+        let arity = arguments.len();
+        let mut f = UninterpretedFn::new_without_constraints(name, arity)?;
+        f.set_all_arguments(arguments)?;
+        f.set_fn_expression(expression, model, own_id)?;
+        Ok(f)
+    }
+
     /// Create uninterpreted function using another one as a template, but changing the expression.
     /// The provided original function object is consumed.
     pub fn with_new_expression(
@@ -297,7 +314,7 @@ mod tests {
         // this test is a hack, normally just edit the function's expression through the `ModelState`
         // object that owns it
 
-        let mut context = ModelState::new();
+        let mut context = ModelState::new_empty();
         context.add_uninterpreted_fn_by_str("f", "f", 3).unwrap();
 
         let fn_id = UninterpretedFnId::new("f").unwrap();

--- a/src-tauri/src/sketchbook/properties/_dynamic_property.rs
+++ b/src-tauri/src/sketchbook/properties/_dynamic_property.rs
@@ -11,9 +11,9 @@ pub struct DynProperty {
     formula: String,
 }
 
-/// Creating properties.
+/// Creating dynamic properties.
 impl DynProperty {
-    /// Create ` DynProperty` object directly from a formula, which must be in a correct format.
+    /// Create `DynProperty` object directly from a formula, which must be in a correct format.
     ///
     /// TODO: add syntax check.
     pub fn try_from_str(formula: &str) -> Result<DynProperty, String> {
@@ -21,7 +21,7 @@ impl DynProperty {
         Ok(DynProperty::new_raw(formula))
     }
 
-    /// **internal** Create ` DynProperty` object directly from a string formula,
+    /// **internal** Create `DynProperty` object directly from a string formula,
     /// without any syntax checks on it.
     fn new_raw(formula: &str) -> Self {
         DynProperty {
@@ -61,12 +61,12 @@ impl DynProperty {
     }
 }
 
-/// Editing properties.
+/// Editing dynamic properties.
 impl DynProperty {
     // TODO
 }
 
-/// Observing properties.
+/// Observing dynamic properties.
 impl DynProperty {
     pub fn get_formula(&self) -> &str {
         &self.formula

--- a/src-tauri/src/sketchbook/properties/_static_property.rs
+++ b/src-tauri/src/sketchbook/properties/_static_property.rs
@@ -4,18 +4,37 @@ use serde::{Deserialize, Serialize};
 ///
 /// TODO: Currently, this is just a placeholder.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
-pub struct StatProperty {}
+pub struct StatProperty {
+    formula: String,
+}
 
 /// Creating properties.
 impl StatProperty {
-    /// TODO - just a placeholder for now
-    pub fn new() -> StatProperty {
-        StatProperty {}
+    /// Create `StatProperty` object directly from a formula, which must be in a correct format.
+    ///
+    /// TODO: add syntax check.
+    pub fn try_from_str(formula: &str) -> Result<StatProperty, String> {
+        // todo: syntax check
+        Ok(StatProperty::new_raw(formula))
+    }
+
+    /// **internal** Create `StatProperty` object directly from a string formula,
+    /// without any syntax checks on it.
+    fn new_raw(formula: &str) -> Self {
+        StatProperty {
+            formula: formula.to_string(),
+        }
     }
 }
 
-impl Default for StatProperty {
-    fn default() -> Self {
-        Self::new()
+/// Editing static properties.
+impl StatProperty {
+    // TODO
+}
+
+/// Observing static properties.
+impl StatProperty {
+    pub fn get_formula(&self) -> &str {
+        &self.formula
     }
 }

--- a/src/aeon_events.ts
+++ b/src/aeon_events.ts
@@ -46,8 +46,15 @@ interface AeonState {
     sketchRefreshed: Observable<SketchData>
     /** Refresh the whole sketch. */
     refreshSketch: () => void
+
     /** Export the sketch data to a file. */
     exportSketch: (path: string) => void
+    /** Import the sketch data from a file. */
+    importSketch: (path: string) => void
+    /** Set the sketch to a "default" mode, essentially emptying it and starting anew. */
+    newSketch: () => void
+    /** The whole modified sketch instance (after importing or starting a new sketch). */
+    sketchReplaced: Observable<SketchData>
 
     /** The state of the main model. */
     model: {
@@ -365,6 +372,7 @@ export interface DynPropertyData {
 /** A PLACEHOLDER object representing a static property. */
 export interface StatPropertyData {
   id: string
+  formula: string
 }
 
 /** An object representing information needed for variable id change. */
@@ -799,6 +807,19 @@ export const aeonState: AeonState = {
       aeonEvents.emitAction({
         path: ['sketch', 'export_sketch'],
         payload: path
+      })
+    },
+    sketchReplaced: new Observable<SketchData>(['sketch', 'set_all']),
+    importSketch (path: string): void {
+      aeonEvents.emitAction({
+        path: ['sketch', 'import_sketch'],
+        payload: path
+      })
+    },
+    newSketch (): void {
+      aeonEvents.emitAction({
+        path: ['sketch', 'new_sketch'],
+        payload: null
       })
     },
 

--- a/src/html/component/content-pane/content-pane.less
+++ b/src/html/component/content-pane/content-pane.less
@@ -14,7 +14,7 @@
 
 .pin-button {
   position: absolute;
-  z-index: 999;
+  z-index: 5;
 }
 
 

--- a/src/html/component/menu/menu.less
+++ b/src/html/component/menu/menu.less
@@ -1,13 +1,53 @@
 @import '/src/uikit-theme';
 
+.menu-content {
+  display: none;
+  flex-direction: column;
+  position: absolute;
+  box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
+  z-index: 100;
+  margin-left: 0.5em;
+}
+
+.menu-item {
+  padding: 0.1em 1em;
+  cursor: pointer;
+}
+
+.menu-item:hover {
+    background: @primary-color;
+}
+
+.show {
+  display: flex;
+}
+
 @media (prefers-color-scheme: dark) {
   .uk-button {
-    background: rgb(34, 34, 34);
+    background: @button-dark;
   }
+
+  .menu-content {
+    background-color: @background-dark;
+  }
+
+  .menu-item > a {
+    color: white;
+  }
+
+
 }
 
 @media (prefers-color-scheme: light) {
   .uk-button {
-    background: rgb(222, 222, 222);
+    background: @button-light;
+  }
+
+  .menu-content {
+    background-color: @background-light;
+  }
+
+  .menu-item {
+    color: black;
   }
 }

--- a/src/html/component/menu/menu.ts
+++ b/src/html/component/menu/menu.ts
@@ -1,14 +1,102 @@
 import { html, css, unsafeCSS, LitElement, type TemplateResult } from 'lit'
-import { customElement } from 'lit/decorators.js'
+import { customElement, query, state } from 'lit/decorators.js'
 import style_less from './menu.less?inline'
+import { map } from 'lit/directives/map.js'
+import { open, save } from '@tauri-apps/api/dialog'
+import { appWindow } from '@tauri-apps/api/window'
+
+// TODO: close menu when clicked outside
 
 @customElement('hamburger-menu')
 export default class Menu extends LitElement {
   static styles = css`${unsafeCSS(style_less)}`
+  @query('.menu-content') declare menuContentElement: HTMLElement
+  @state() menuVisible = false
+  @state() menuItems: IMenuItem[] = [
+    {
+      label: 'New sketch',
+      action: () => { console.log('new') }
+    },
+    {
+      label: 'Import...',
+      action: () => { void this.import() }
+    },
+    {
+      label: 'Export...',
+      action: () => { void this.export() }
+    },
+    {
+      label: 'Quit',
+      action: this.quit
+    }
+  ]
+
+  async import (): Promise<void> {
+    let selected = await open({
+      title: 'Import sketch...',
+      multiple: false,
+      filters: [{
+        name: '*.json',
+        extensions: ['json']
+      }]
+    })
+    if (selected === null) return
+    if (Array.isArray(selected)) {
+      if (selected.length > 0) { selected = selected[0] }
+    }
+
+    console.log('importing', selected)
+  }
+
+  async export (): Promise<void> {
+    const filePath = await save({
+      title: 'Export sketch...',
+      filters: [{
+        name: '*.json',
+        extensions: ['json']
+      }],
+      defaultPath: 'project_name_here'
+    })
+    if (filePath === null) return
+
+    console.log('exporting to', filePath)
+  }
+
+  quit (): void {
+    void appWindow.close()
+  }
+
+  private toggleMenu (): void {
+    this.menuVisible = !this.menuVisible
+  }
+
+  private itemClick (action: () => void): void {
+    this.toggleMenu()
+    action()
+  }
 
   render (): TemplateResult {
     return html`
-      <button class="uk-button uk-button-small hamburger-menu uk-margin-small-left">☰</button>
+      <button class="uk-button uk-button-small hamburger-menu uk-margin-small-left"
+      @click="${this.toggleMenu}">☰</button>
+      <div class="menu-content ${this.menuVisible ? 'show' : ''}">
+        <ul class="uk-nav">
+          ${map(this.menuItems, (item) => html`
+            <li class="menu-item" @click="${() => {
+              this.itemClick(item.action)
+            }}">
+              <a>
+                ${item.label}
+              </a>
+            </li>
+          `)}
+        </ul>
+      </div>
     `
   }
+}
+
+interface IMenuItem {
+  label: string
+  action: () => void
 }

--- a/src/html/component/nav-bar/nav-bar.less
+++ b/src/html/component/nav-bar/nav-bar.less
@@ -2,8 +2,7 @@
 
 .nav-bar {
   white-space: nowrap;
-  z-index: 998;
-  overflow: hidden;
+  z-index: 100;
   position: relative;
 }
 

--- a/src/html/component/observations-editor/observations-editor.ts
+++ b/src/html/component/observations-editor/observations-editor.ts
@@ -14,7 +14,8 @@ import {
   type DatasetData,
   type DatasetIdUpdateData,
   type ObservationData,
-  type ObservationIdUpdateData
+  type ObservationIdUpdateData,
+  type SketchData
 } from '../../../aeon_events'
 
 @customElement('observations-editor')
@@ -42,6 +43,9 @@ export default class ObservationsEditor extends LitElement {
 
     // refresh-event listeners
     aeonState.sketch.observations.datasetsRefreshed.addEventListener(this.#onDatasetsRefreshed.bind(this))
+    // when refreshing/replacing whole sketch, this component is responsible for updating the `Datasets` part
+    aeonState.sketch.sketchRefreshed.addEventListener(this.#onSketchRefreshed.bind(this))
+    aeonState.sketch.sketchReplaced.addEventListener(this.#onSketchRefreshed.bind(this))
 
     // refreshing content from backend
     aeonState.sketch.observations.refreshDatasets()
@@ -85,6 +89,11 @@ export default class ObservationsEditor extends LitElement {
       variables: dataset.variables,
       category: dataset.category
     }
+  }
+
+  #onSketchRefreshed (sketch: SketchData): void {
+    // when refreshing/replacing whole sketch, this component is responsible for updating the `Datasets` part
+    this.#onDatasetsRefreshed(sketch.datasets)
   }
 
   #onDatasetsRefreshed (refreshedDatasets: DatasetData[]): void {

--- a/src/html/component/root-component/root-component.ts
+++ b/src/html/component/root-component/root-component.ts
@@ -11,6 +11,7 @@ import {
   type LayoutNodeDataPrototype,
   type ModelData,
   type RegulationData,
+  type SketchData,
   type UninterpretedFnData,
   type VariableData,
   type VariableIdUpdateData
@@ -80,6 +81,9 @@ export default class RootComponent extends LitElement {
     aeonState.sketch.model.variablesRefreshed.addEventListener(this.#onVariablesRefreshed.bind(this))
     aeonState.sketch.model.layoutNodesRefreshed.addEventListener(this.#onLayoutNodesRefreshed.bind(this))
     aeonState.sketch.model.regulationsRefreshed.addEventListener(this.#onRegulationsRefreshed.bind(this))
+    // when refreshing/replacing whole sketch, this component is responsible for updating the `Model` part
+    aeonState.sketch.sketchRefreshed.addEventListener(this.#onSketchRefreshed.bind(this))
+    aeonState.sketch.sketchReplaced.addEventListener(this.#onSketchRefreshed.bind(this))
     // event listener to capture changes from FunctionEditor with updated uninterpreted functions
     this.addEventListener('save-functions', this.saveFunctionData.bind(this))
 
@@ -353,6 +357,11 @@ export default class RootComponent extends LitElement {
       function: fnData.expression,
       variables
     }
+  }
+
+  #onSketchRefreshed (sketch: SketchData): void {
+    // when refreshing/replacing whole sketch, this component is responsible for updating the `Model` part
+    this.#onModelRefreshed(sketch.model)
   }
 
   #onModelRefreshed (model: ModelData): void {

--- a/src/uikit-theme.less
+++ b/src/uikit-theme.less
@@ -1,13 +1,16 @@
 // Place any UIKit custom code here.
 
-// Consequently, Vite will know (based on this file name) to fix the 
+// Consequently, Vite will know (based on this file name) to fix the
 // internal image paths inside UIKit to the correct values.
 
 @import "uikit/src/less/uikit.theme.less";
 
 @global-link-color: #DA7D02;
+@primary-color: #5282ee;
 @background-light: #f2f2f2;
 @background-dark: #2f2f2f;
+@button-light: rgb(222, 222, 222);
+@button-dark: rgb(34, 34, 34);
 
 body {
   margin: 0;


### PR DESCRIPTION
This PR mainly implements import and export functionality. The app menu now offers options to 
- export sketch in JSON format
- import sketch from JSON format
- start editing a new sketch

On the backend, this is handled by the newly extended `sketch` object. 

The public API of the `ModelState` module was also slightly extended to allow for more straightforward import. The same goes for several data structures.