### PR TITLE
Extended AEON format for sketch import/export

### DIFF
--- a/data/test_data/test_model_with_data.aeon
+++ b/data/test_data/test_model_with_data.aeon
@@ -1,0 +1,35 @@
+C -?? A
+C -| C
+D -> B
+D -? D
+B -> C
+A -> C
+A -> B
+$A: h(C)
+$B: f(A, D)
+$C: A & g(C, B)
+#position:A:346.89832,183.03789
+#position:C:504.7078,101.93903
+#position:B:0,0
+#position:D:642.49677,185.15988
+#!dataset:data_fp:#`{"name":"data_fp","id":"data_fp","annotation":"","observations":[{"id":"ones","name":"ones","annotation":"","dataset":"data_fp","values":"1111"},{"id":"zeros","name":"zeros","annotation":"","dataset":"data_fp","values":"0000"}],"variables":["A","B","C","D"]}`#
+#!dataset:data_mts:#`{"name":"data_mts","id":"data_mts","annotation":"","observations":[{"id":"abc","name":"abc","annotation":"","dataset":"data_mts","values":"111*"},{"id":"ab","name":"ab","annotation":"","dataset":"data_mts","values":"11**"}],"variables":["A","B","C","D"]}`#
+#!dataset:data_time_series:#`{"name":"data_time_series","id":"data_time_series","annotation":"","observations":[{"id":"a","name":"a","annotation":"","dataset":"data_time_series","values":"1000"},{"id":"b","name":"b","annotation":"","dataset":"data_time_series","values":"1100"},{"id":"c","name":"c","annotation":"","dataset":"data_time_series","values":"1110"},{"id":"d","name":"d","annotation":"","dataset":"data_time_series","values":"1111"}],"variables":["A","B","C","D"]}`#
+#!function:f:#`{"id":"f","name":"f","annotation":"","arguments":[["Unknown","Unknown"],["Unknown","Unknown"]],"expression":""}`#
+#!function:g:#`{"id":"g","name":"g","annotation":"","arguments":[["Unknown","Unknown"],["Unknown","Unknown"]],"expression":""}`#
+#!function:h:#`{"id":"h","name":"h","annotation":"","arguments":[["Unknown","Unknown"]],"expression":""}`#
+#!static_property:essentiality_A_B:#`{"id":"essentiality_A_B","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"A","target":"B","value":"True","context":null}`#
+#!static_property:essentiality_A_C:#`{"id":"essentiality_A_C","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"A","target":"C","value":"True","context":null}`#
+#!static_property:essentiality_B_C:#`{"id":"essentiality_B_C","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"B","target":"C","value":"True","context":null}`#
+#!static_property:essentiality_C_C:#`{"id":"essentiality_C_C","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"C","target":"C","value":"True","context":null}`#
+#!static_property:essentiality_D_B:#`{"id":"essentiality_D_B","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"D","target":"B","value":"True","context":null}`#
+#!static_property:essentiality_D_D:#`{"id":"essentiality_D_D","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"D","target":"D","value":"True","context":null}`#
+#!static_property:monotonicity_A_B:#`{"id":"monotonicity_A_B","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"A","target":"B","value":"Activation","context":null}`#
+#!static_property:monotonicity_A_C:#`{"id":"monotonicity_A_C","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"A","target":"C","value":"Activation","context":null}`#
+#!static_property:monotonicity_B_C:#`{"id":"monotonicity_B_C","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"B","target":"C","value":"Activation","context":null}`#
+#!static_property:monotonicity_C_C:#`{"id":"monotonicity_C_C","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"C","target":"C","value":"Inhibition","context":null}`#
+#!static_property:monotonicity_D_B:#`{"id":"monotonicity_D_B","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"D","target":"B","value":"Activation","context":null}`#
+#!variable:A:#`{"id":"A","name":"A","annotation":"","update_fn":"h(C)"}`#
+#!variable:B:#`{"id":"B","name":"B","annotation":"","update_fn":"f(A, D)"}`#
+#!variable:C:#`{"id":"C","name":"C","annotation":"","update_fn":"A & g(C, B)"}`#
+#!variable:D:#`{"id":"D","name":"D","annotation":"","update_fn":""}`#

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-biodivine-lib-bdd = ">=0.5.19, <1.0.0"
-biodivine-lib-param-bn = ">=0.5.11, <1.0.0"
-biodivine-hctl-model-checker = ">=0.3.0, <1.0.0"
+biodivine-lib-bdd = ">=0.5.22, <1.0.0"
+biodivine-lib-param-bn = ">=0.5.13, <1.0.0"
+biodivine-hctl-model-checker = ">=0.3.1, <1.0.0"
 chrono = "0.4.38"
 csv = "1.3"
 lazy_static = "1.5.0"

--- a/src-tauri/src/analysis/results_export.rs
+++ b/src-tauri/src/analysis/results_export.rs
@@ -9,12 +9,14 @@ use std::path::Path;
 use zip::write::{FileOptions, ZipWriter};
 
 /// Export archive with complete results to the given path.
+/// The output archive is tailored for a case where sketch is satisfiable.
+///
 /// The results archive include:
 /// - a summary report (basically information tracked by the `InferenceResults` struct)
 /// - original sketch in JSON format for replicability in SketchBook
 /// - BDD with satisfying colors
 /// - a PSBN model derived from the sketch (in aeon format) that can be used as a context for the BDD
-/// - a folder with update function variants per variable
+/// - a folder with admissible update function variants per variable
 pub fn export_results(
     path: &str,
     finished_solver: &FinishedInferenceSolver,
@@ -81,6 +83,8 @@ fn write_to_zip(
     Ok(())
 }
 
+/// Prepare a formated summary of inference results, basically a "report" on the
+/// computation progress and results.
 fn format_inference_results(results: &InferenceResults) -> String {
     let mut output = String::new();
 
@@ -129,7 +133,8 @@ fn format_inference_results(results: &InferenceResults) -> String {
 }
 
 /// For a given variable, get all valid interpretations of its update function present in the
-/// satisfying `colors` (taken from the results of the solver). Variable must be present in the network.
+/// satisfying `colors` (taken from the results of the solver).
+/// Variable must be present in the network.
 pub fn get_update_fn_variants_from_solver(
     solver: &FinishedInferenceSolver,
     var_name: &str,

--- a/src-tauri/src/sketchbook/_sketch/_impl_export.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_export.rs
@@ -1,4 +1,8 @@
-use crate::sketchbook::data_structs::SketchData;
+use biodivine_lib_param_bn::ModelAnnotation;
+
+use crate::sketchbook::data_structs::{
+    DatasetData, DynPropertyData, SketchData, StatPropertyData, UninterpretedFnData, VariableData,
+};
 use crate::sketchbook::{JsonSerde, Sketch};
 use std::fs::File;
 use std::io::Write;
@@ -20,6 +24,80 @@ impl Sketch {
         let mut file = File::create(filepath).map_err(|e| e.to_string())?;
         // write sketch in JSON to the file
         file.write_all(json_str.as_bytes())
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+impl Sketch {
+    /// Convert the sketch instance into a customized version of AEON model format.
+    ///
+    /// This format includes the standard AEON format for PSBN and layout.
+    /// This format is compatible with other biodivine tools, but might not cover all
+    /// parts of the sketch.
+    /// 
+    /// Apart from that, all details of the sketch are given via model annotations.
+    /// Currently the annotations are given simpy as `component_type: id: json_string`.
+    /// These components can be variables, functions, properties, of datasets.
+    pub fn to_aeon(&self) -> String {
+        // for standard part of aeon format, we use the transformation into aeon BN
+        // this loses some info (like new regulation types), but that is preserved via annotations
+        let bn = self.model.to_bn();
+        let mut aeon_str = bn.to_string();
+
+        // set layout info
+        let default_layout = self.model.get_default_layout();
+        for (var_id, node) in default_layout.layout_nodes() {
+            // write position in format #position:ID:X,Y
+            let pos = node.get_position();
+            let node_layout_str = format!("#position:{var_id}:{},{}\n", pos.0, pos.1);
+            aeon_str.push_str(&node_layout_str);
+        }
+
+        // set the rest using aeon model annotations
+        let mut annotation = ModelAnnotation::new();
+
+        // set static properties
+        for (id, stat_prop) in self.properties.stat_props() {
+            let prop_data_json = StatPropertyData::from_property(id, stat_prop).to_json_str();
+            annotation.ensure_value(&["static_property", id.as_str()], &prop_data_json);
+        }
+        // set dynamic properties
+        for (id, dyn_prop) in self.properties.dyn_props() {
+            let prop_data_json = DynPropertyData::from_property(id, dyn_prop).to_json_str();
+            annotation.ensure_value(&["dynamic_property", id.as_str()], &prop_data_json);
+        }
+        // set datasets
+        for (id, dataset) in self.observations.datasets() {
+            let dataset_data_json = DatasetData::from_dataset(id, dataset).to_json_str();
+            annotation.ensure_value(&["dataset", id.as_str()], &dataset_data_json);
+        }
+        // set variable details
+        for (var_id, variable) in self.model.variables() {
+            let update_fn = self.model.get_update_fn(var_id).unwrap();
+            let var_data_json = VariableData::from_var(var_id, variable, update_fn).to_json_str();
+            annotation.ensure_value(&["variable", var_id.as_str()], &var_data_json);
+        }
+        // set function details
+        for (fn_id, uninterpreted_fn) in self.model.uninterpreted_fns() {
+            let fn_data_json = UninterpretedFnData::from_fn(fn_id, uninterpreted_fn).to_json_str();
+            annotation.ensure_value(&["function", fn_id.as_str()], &fn_data_json);
+        }
+
+        // push the annotations to the aeon string
+        let annotation_str = annotation.to_string();
+        aeon_str.push_str(&annotation_str);
+        aeon_str
+    }
+
+    /// Export the sketch instance into a customized version of AEON model format.
+    ///
+    /// See [Sketch::to_aeon] for details on the actual conversion.
+    pub fn export_to_aeon(&self, filepath: &str) -> Result<(), String> {
+        let aeon_str = self.to_aeon();
+        let mut file = File::create(filepath).map_err(|e| e.to_string())?;
+        // write sketch in AEON to the file
+        file.write_all(aeon_str.as_bytes())
             .map_err(|e| e.to_string())?;
         Ok(())
     }

--- a/src-tauri/src/sketchbook/_sketch/_impl_export.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_export.rs
@@ -35,10 +35,11 @@ impl Sketch {
     /// This format includes the standard AEON format for PSBN and layout.
     /// This format is compatible with other biodivine tools, but might not cover all
     /// parts of the sketch.
-    /// 
-    /// Apart from that, all details of the sketch are given via model annotations.
-    /// Currently the annotations are given simpy as `component_type: id: json_string`.
-    /// These components can be variables, functions, properties, of datasets.
+    ///
+    /// Apart from that, most remaining details of the sketch are given via model annotations.
+    /// Currently the annotations are given simpy as
+    ///   #!entity_type: ID: #`json_string`#
+    /// These entities can be variables, functions, static/dynamic properties, and datasets.
     pub fn to_aeon(&self) -> String {
         // for standard part of aeon format, we use the transformation into aeon BN
         // this loses some info (like new regulation types), but that is preserved via annotations

--- a/src-tauri/src/sketchbook/_sketch/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_session_state.rs
@@ -31,6 +31,10 @@ impl SessionState for Sketch {
             let path = Self::clone_payload_str(event, "sketch")?;
             self.export_to_custom_json(&path)?;
             Ok(Consumed::NoChange)
+        } else if Self::starts_with("export_aeon", at_path).is_some() {
+            let path = Self::clone_payload_str(event, "sketch")?;
+            self.export_to_aeon(&path)?;
+            Ok(Consumed::NoChange)
         } else if Self::starts_with("import_sketch", at_path).is_some() {
             let file_path = Self::clone_payload_str(event, "sketch")?;
             // read the file contents

--- a/src-tauri/src/sketchbook/data_structs/mod.rs
+++ b/src-tauri/src/sketchbook/data_structs/mod.rs
@@ -27,7 +27,7 @@ mod _uninterpreted_fn_data;
 mod _variable_data;
 
 pub use _dataset_data::{DatasetData, DatasetMetaData};
-pub use _dynamic_prop_data::DynPropertyData;
+pub use _dynamic_prop_data::{DynPropertyData, DynPropertyTypeData};
 pub use _fn_arg_change_data::{ChangeArgEssentialData, ChangeArgMonotoneData};
 pub use _id_change_data::ChangeIdData;
 pub use _layout_data::{LayoutData, LayoutMetaData};
@@ -36,6 +36,6 @@ pub use _model_data::ModelData;
 pub use _observation_data::ObservationData;
 pub use _regulation_data::RegulationData;
 pub use _sketch_data::SketchData;
-pub use _static_prop_data::StatPropertyData;
+pub use _static_prop_data::{StatPropertyData, StatPropertyTypeData};
 pub use _uninterpreted_fn_data::UninterpretedFnData;
 pub use _variable_data::{VariableData, VariableWithLayoutData};

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
@@ -228,6 +228,12 @@ impl ModelState {
             .ok_or(format!("Layout with ID {id} does not exist in this model."))
     }
 
+    /// Return a default `Layout`.
+    pub fn get_default_layout(&self) -> &Layout {
+        let default_id = ModelState::get_default_layout_id();
+        self.layouts.get(&default_id).unwrap()
+    }
+
     /// Return a valid layout's `LayoutId` corresponding to the Id given by a `String`.
     ///
     /// Return `Err` if such variable does not exist (and the ID is invalid).

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -175,8 +175,10 @@ interface AeonState {
     /** Refresh the whole sketch. */
     refreshSketch: () => void
 
-    /** Export the sketch data to a file. */
+    /** Export the sketch data to a file in the custom JSON format. */
     exportSketch: (path: string) => void
+    /** Export the sketch data to a file in the extended AEON format. */
+    exportAeon: (path: string) => void
     /** Import the sketch data from a special sketch JSON file. */
     importSketch: (path: string) => void
     /** Import the sketch data from a AEON file. */
@@ -597,6 +599,12 @@ export const aeonState: AeonState = {
     exportSketch (path: string): void {
       aeonEvents.emitAction({
         path: ['sketch', 'export_sketch'],
+        payload: path
+      })
+    },
+    exportAeon (path: string): void {
+      aeonEvents.emitAction({
+        path: ['sketch', 'export_aeon'],
         payload: path
       })
     },

--- a/src/html/component-analysis/analysis-component/analysis-component.ts
+++ b/src/html/component-analysis/analysis-component/analysis-component.ts
@@ -218,21 +218,24 @@ export default class AnalysisComponent extends LitElement {
       .map(statusReport => statusReport.message)
       .join('\n')
 
-    // prepare the summary with update functions per variable, sorted by var name
-    const updateFnsSummary = Object.entries(results.num_update_fns_per_var)
-      .sort(([varNameA], [varNameB]) => varNameA.localeCompare(varNameB))
-      .map(([varName, count]) => {
-        const countDisplay = count >= 1000 ? 'more than 1000' : count.toString()
-        return `${varName}: ${countDisplay}`
-      })
-      .join('\n')
+    let resultsMessage = '--------------\nExtended summary:\n--------------\n' +
+      `${results.summary_message}\n`
+    if (results.num_sat_networks > 0) {
+      // prepare the summary with update functions per variable, sorted by var name
+      const updateFnsSummary = Object.entries(results.num_update_fns_per_var)
+        .sort(([varNameA], [varNameB]) => varNameA.localeCompare(varNameB))
+        .map(([varName, count]) => {
+          const countDisplay = count >= 1000 ? 'more than 1000' : count.toString()
+          return `${varName}: ${countDisplay}`
+        })
+        .join('\n')
 
-    return '--------------\nExtended summary:\n--------------\n' +
-      `${results.summary_message}\n` +
-      '--------------\nNumber of admissible update functions per variable:\n--------------\n' +
-      updateFnsSummary + '\n\n' +
-      '--------------\nDetailed progress report:\n--------------\n' +
+      resultsMessage += '--------------\nNumber of admissible update functions per variable:\n--------------\n' +
+        updateFnsSummary + '\n\n'
+    }
+    resultsMessage += '--------------\nDetailed progress report:\n--------------\n' +
       progressSummary
+    return resultsMessage
   }
 
   private async resetAnalysis (): Promise<void> {

--- a/src/html/component-editor/menu/menu.ts
+++ b/src/html/component-editor/menu/menu.ts
@@ -39,6 +39,10 @@ export default class Menu extends LitElement {
       action: () => { void this.exportSketch() }
     },
     {
+      label: 'Export AEON',
+      action: () => { void this.exportAeon() }
+    },
+    {
       label: 'Quit',
       action: () => { void this.quit() }
     }
@@ -99,7 +103,7 @@ export default class Menu extends LitElement {
 
   async exportSketch (): Promise<void> {
     const filePath = await save({
-      title: 'Export sketch...',
+      title: 'Export sketch in JSON format...',
       filters: [{
         name: '*.json',
         extensions: ['json']
@@ -108,8 +112,23 @@ export default class Menu extends LitElement {
     })
     if (filePath === null) return
 
-    console.log('exporting to', filePath)
+    console.log('exporting json to', filePath)
     aeonState.sketch.exportSketch(filePath)
+  }
+
+  async exportAeon (): Promise<void> {
+    const filePath = await save({
+      title: 'Export sketch in extended AEON format...',
+      filters: [{
+        name: '*.aeon',
+        extensions: ['aeon']
+      }],
+      defaultPath: 'project_name_here'
+    })
+    if (filePath === null) return
+
+    console.log('exporting aeon to', filePath)
+    aeonState.sketch.exportAeon(filePath)
   }
 
   async newSketch (): Promise<void> {


### PR DESCRIPTION
In this PR, we are focusing on extending the AEON format to cover the whole sketch. We've currently developed a new system to specify details regarding variables, functions, datasets, and properties via AEON format annotations. 

The annotations will have the following structure:
- ```#!entity_type: ID: #`json_string`#```

We also allow a special case for writing HCTL and FOL properties, compatible with the format used in BN sketches prototype:
- ```#!static_property: ID: #`fol_formula_string`#```
- ```#!dynamic_property: ID: #`hctl_formula_string`#```

The original parts of the AEON format (variables, regulations, update functions, and layout) are still the same, making the model compatible with all `biodivine` libraries (the only difference is in the new annotations). In future, we might make the format rely more on the annotation system itself, instead of encoding the entities with JSON. We should also look into some of the edge cases, like the new types of regulations not supported by AEON.

We have extended the functions for AEON import, and we have added a new AEON export feature (both based on the new extension).

We have also updated dependencies to all `biodivine` libraries. This allows us to utilize the newly extended HCTL syntax of the `hctl-model-checker`. We can now specify hybrid operators the same way we can specify FOL quantifiers - using their names (prefixed by a backslash): `\bind`, `\jump`, `\exists`, `\forall`. You can use this syntax to write a formula like `\bind {x}: AG EF {x}`.

