### PR TITLE
Refinement of long-standing UX items

### DIFF
--- a/data/run_inference_all_models.py
+++ b/data/run_inference_all_models.py
@@ -8,6 +8,8 @@ MODEL_PATHS = [
     "test_data/test_sketch_1.json",
     "test_data/test_sketch_2.aeon",
     "test_data/test_sketch_2.json",
+    "test_data/test_model_various_regulations.aeon",
+    "test_data/test_model_various_regulations.json",
     "real_cases/arabidopsis/arabidopsis_sketch.aeon",
     "real_cases/arabidopsis/arabidopsis_sketch_hctl.json",
     "real_cases/arabidopsis/arabidopsis_sketch.json",

--- a/data/run_inference_all_models_expected.txt
+++ b/data/run_inference_all_models_expected.txt
@@ -1,0 +1,330 @@
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+>>>>>>>>>> START INFERENCE RUN
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+==========================
+Model test_data/test_sketch_1.aeon
+==========================
+
+Number of candidates: 32
+Computation time: 24ms
+N. of candidates before evaluating any properties: 4096
+N. of candidates after evaluating static props: 32
+N. of candidates after evaluating dynamic props: 32
+
+==========================
+Model test_data/test_sketch_1.json
+==========================
+
+Number of candidates: 32
+Computation time: 26ms
+N. of candidates before evaluating any properties: 4096
+N. of candidates after evaluating static props: 32
+N. of candidates after evaluating dynamic props: 32
+
+==========================
+Model test_data/test_sketch_2.aeon
+==========================
+
+Number of candidates: 32
+Computation time: 23ms
+N. of candidates before evaluating any properties: 4096
+N. of candidates after evaluating static props: 32
+N. of candidates after evaluating dynamic props: 32
+
+==========================
+Model test_data/test_sketch_2.json
+==========================
+
+Number of candidates: 32
+Computation time: 24ms
+N. of candidates before evaluating any properties: 4096
+N. of candidates after evaluating static props: 32
+N. of candidates after evaluating dynamic props: 32
+
+==========================
+Model test_data/test_model_various_regulations.aeon
+==========================
+
+Number of candidates: 0
+Computation time: 9ms
+N. of candidates before evaluating any properties: 16384
+N. of candidates after evaluating static props: 0
+Sketch found unsatisfiable after processing 1 static and 0 dynamic properties
+
+==========================
+Model test_data/test_model_various_regulations.json
+==========================
+
+Number of candidates: 0
+Computation time: 7ms
+N. of candidates before evaluating any properties: 16384
+N. of candidates after evaluating static props: 0
+Sketch found unsatisfiable after processing 1 static and 0 dynamic properties
+
+==========================
+Model real_cases/arabidopsis/arabidopsis_sketch.aeon
+==========================
+
+Number of candidates: 439296
+Computation time: 347ms
+N. of candidates before evaluating any properties: 295147905179352825856
+N. of candidates after evaluating static props: 4761711360
+N. of candidates after evaluating dynamic props: 439296
+
+==========================
+Model real_cases/arabidopsis/arabidopsis_sketch_hctl.json
+==========================
+
+Number of candidates: 439296
+Computation time: 640ms
+N. of candidates before evaluating any properties: 295147905179352825856
+N. of candidates after evaluating static props: 4761711360
+N. of candidates after evaluating dynamic props: 439296
+
+==========================
+Model real_cases/arabidopsis/arabidopsis_sketch.json
+==========================
+
+Number of candidates: 439296
+Computation time: 383ms
+N. of candidates before evaluating any properties: 295147905179352825856
+N. of candidates after evaluating static props: 4761711360
+N. of candidates after evaluating dynamic props: 439296
+
+==========================
+Model real_cases/arabidopsis/arabidopsis_with_additional_prop.json
+==========================
+
+Number of candidates: 48352
+Computation time: 1903ms
+N. of candidates before evaluating any properties: 295147905179352825856
+N. of candidates after evaluating static props: 4761711360
+N. of candidates after evaluating dynamic props: 48352
+
+==========================
+Model real_cases/tlgl/tlgl_sketch.aeon
+==========================
+
+Number of candidates: 486
+Computation time: 801ms
+N. of candidates before evaluating any properties: 72057594037927936
+N. of candidates after evaluating static props: 1296
+N. of candidates after evaluating dynamic props: 486
+
+==========================
+Model real_cases/tlgl/tlgl_sketch.json
+==========================
+
+Number of candidates: 486
+Computation time: 838ms
+N. of candidates before evaluating any properties: 72057594037927936
+N. of candidates after evaluating static props: 1296
+N. of candidates after evaluating dynamic props: 486
+
+==========================
+Model real_cases/tlgl/tlgl_sketch_hctl.json
+==========================
+
+Number of candidates: 486
+Computation time: 872ms
+N. of candidates before evaluating any properties: 72057594037927936
+N. of candidates after evaluating static props: 1296
+N. of candidates after evaluating dynamic props: 486
+
+==========================
+Model small_example/small_example_sketch.json
+==========================
+
+Number of candidates: 1
+Computation time: 16ms
+N. of candidates before evaluating any properties: 64
+N. of candidates after evaluating static props: 12
+N. of candidates after evaluating dynamic props: 1
+
+==========================
+Model small_example/small_example_sketch.aeon
+==========================
+
+Number of candidates: 1
+Computation time: 16ms
+N. of candidates before evaluating any properties: 64
+N. of candidates after evaluating static props: 12
+N. of candidates after evaluating dynamic props: 1
+
+==========================
+Model small_example/previous_version/small_example.aeon
+==========================
+
+Number of candidates: 1
+Computation time: 13ms
+N. of candidates before evaluating any properties: 256
+N. of candidates after evaluating static props: 16
+N. of candidates after evaluating dynamic props: 1
+
+==========================
+Model small_example/previous_version/small_example.json
+==========================
+
+Number of candidates: 1
+Computation time: 13ms
+N. of candidates before evaluating any properties: 256
+N. of candidates after evaluating static props: 16
+N. of candidates after evaluating dynamic props: 1
+
+==========================
+Model benchmarks/celldivb/celldivb_sketch.aeon
+==========================
+
+Number of candidates: 14088
+Computation time: 226ms
+N. of candidates before evaluating any properties: 16777216
+N. of candidates after evaluating static props: 64000
+N. of candidates after evaluating dynamic props: 14088
+
+==========================
+Model benchmarks/eprotein/eprotein_sketch.aeon
+==========================
+
+Number of candidates: 1008
+Computation time: 1807ms
+N. of candidates before evaluating any properties: 18889465931478580854784
+N. of candidates after evaluating static props: 944784
+N. of candidates after evaluating dynamic props: 1008
+
+==========================
+Model benchmarks/nsp4/nsp4_sketch.aeon
+==========================
+
+Number of candidates: 128
+Computation time: 1571ms
+N. of candidates before evaluating any properties: 75557863725914323419136
+N. of candidates after evaluating static props: 1179648
+N. of candidates after evaluating dynamic props: 128
+
+==========================
+Model benchmarks/etc/etc_sketch.aeon
+Model benchmarks/etc/etc_sketch.aeon
+==========================
+
+Number of candidates: 3167262
+Computation time: 410964ms
+N. of candidates before evaluating any properties: 4722366482869645213696
+N. of candidates after evaluating static props: 242337096
+N. of candidates after evaluating dynamic props: 3167262
+
+==========================
+Model benchmarks/interferon/interferon_sketch.aeon
+==========================
+
+Number of candidates: 682290
+Computation time: 318617ms
+N. of candidates before evaluating any properties: 10141204801825835211973625643008
+N. of candidates after evaluating static props: 53378248050663953006592
+N. of candidates after evaluating dynamic props: 682290
+
+==========================
+Model benchmarks/nsp9/nsp9_sketch.aeon
+==========================
+==========================
+
+Number of candidates: 55145152512
+Computation time: 35866ms
+N. of candidates before evaluating any properties: 85070591730234615865843651857942052864
+N. of candidates after evaluating static props: 3143273693184
+N. of candidates after evaluating dynamic props: 55145152512
+
+==========================
+Model benchmarks/macrophage/macrophage_sketch.aeon
+==========================
+
+Number of candidates: 787353224904
+Computation time: 574625ms
+N. of candidates before evaluating any properties: 20282409603651670423947251286016
+N. of candidates after evaluating static props: 9973140848784
+N. of candidates after evaluating dynamic props: 787353224904
+
+==========================
+Model other_sketches/fgf_signalling/fgf_sketch.json
+==========================
+
+Number of candidates: 1
+Computation time: 33ms
+N. of candidates before evaluating any properties: 4096
+N. of candidates after evaluating static props: 8
+N. of candidates after evaluating dynamic props: 1
+
+==========================
+Model other_sketches/myeloid/myeloid-sketch-no-updates.json
+==========================
+
+Number of candidates: 5451624
+Computation time: 4585ms
+N. of candidates before evaluating any properties: 19807040628566084398385987584
+N. of candidates after evaluating static props: 48642052608
+N. of candidates after evaluating dynamic props: 5451624
+
+==========================
+Model other_sketches/oscillatory_models/bovine_estrous/bovine-estrous_model_final_cutdown.json
+==========================
+
+Number of candidates: 271488
+Computation time: 11543ms
+N. of candidates before evaluating any properties: 1208925819614629174706176
+N. of candidates after evaluating static props: 638673984
+N. of candidates after evaluating dynamic props: 271488
+
+==========================
+Model other_sketches/oscillatory_models/gyn_cycle/FSH_submodel/FSH_submodel.json
+==========================
+
+Number of candidates: 113275314
+Computation time: 281263ms
+N. of candidates before evaluating any properties: 295147905179352825856
+N. of candidates after evaluating static props: 127318392
+N. of candidates after evaluating dynamic props: 113275314
+
+==========================
+Model other_sketches/oscillatory_models/gyn_cycle/GnRH_submodel/GnRH_submodel.json
+==========================
+
+Number of candidates: 966152038
+Computation time: 255853ms
+N. of candidates before evaluating any properties: 75557863725914323419136
+N. of candidates after evaluating static props: 1612699632
+N. of candidates after evaluating dynamic props: 966152038
+
+==========================
+Model other_sketches/oscillatory_models/gyn_cycle/LH_submodel/LH_submodel.json
+==========================
+
+Number of candidates: 0
+Computation time: 1101ms
+N. of candidates before evaluating any properties: 36028797018963968
+N. of candidates after evaluating static props: 16842816
+N. of candidates after evaluating dynamic props: 0
+Sketch found unsatisfiable after processing 32 static and 1 dynamic properties
+
+==========================
+Model other_sketches/oscillatory_models/gyn_cycle/reduced_submodel/gyn-cycle_model_red_ts_properties_31k.json     
+==========================
+
+Number of candidates: 8712
+Computation time: 79790ms
+N. of candidates before evaluating any properties: 17592186044416
+N. of candidates after evaluating static props: 31104
+N. of candidates after evaluating dynamic props: 8712
+
+==========================
+Model other_sketches/oscillatory_models/predator_prey/predator-prey_model_final.json
+==========================
+
+Number of candidates: 1
+Computation time: 7ms
+N. of candidates before evaluating any properties: 256
+N. of candidates after evaluating static props: 256
+N. of candidates after evaluating dynamic props: 1
+
+==========================
+ALL COMPUTATIONS COMPLETED SUCCESSFULLY
+==========================

--- a/data/test_data/test_model_various_regulations.aeon
+++ b/data/test_data/test_model_various_regulations.aeon
@@ -1,0 +1,39 @@
+A -| D
+A -? A
+A ->? C
+B -? C
+D -?? B
+A -> B
+D -?? D
+C -|? C
+C -?? A
+B -?? B
+$A: h(C)
+$B: f(A, D)
+$C: A & g(C, B)
+#position:A:346.89832,183.03789
+#position:C:504.7078,101.93903
+#position:D:642.49677,185.15988
+#position:B:503,269.6
+#!function:f:#`{"id":"f","name":"f","annotation":"","arguments":[["Unknown","Unknown"],["Unknown","Unknown"]],"expression":""}`#
+#!function:g:#`{"id":"g","name":"g","annotation":"","arguments":[["Unknown","Unknown"],["Unknown","Unknown"]],"expression":""}`#
+#!function:h:#`{"id":"h","name":"h","annotation":"","arguments":[["Unknown","Unknown"]],"expression":""}`#
+#!static_property:essentiality_A_A:#`{"id":"essentiality_A_A","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"A","target":"A","value":"True","context":null}`#
+#!static_property:essentiality_A_B:#`{"id":"essentiality_A_B","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"A","target":"B","value":"True","context":null}`#
+#!static_property:essentiality_A_C:#`{"id":"essentiality_A_C","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"A","target":"C","value":"False","context":null}`#
+#!static_property:essentiality_A_D:#`{"id":"essentiality_A_D","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"A","target":"D","value":"True","context":null}`#
+#!static_property:essentiality_B_C:#`{"id":"essentiality_B_C","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"B","target":"C","value":"True","context":null}`#
+#!static_property:essentiality_C_A:#`{"id":"essentiality_C_A","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"C","target":"A","value":"False","context":null}`#
+#!static_property:essentiality_C_C:#`{"id":"essentiality_C_C","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"C","target":"C","value":"False","context":null}`#
+#!static_property:essentiality_D_B:#`{"id":"essentiality_D_B","name":"Regulation essentiality (generated)","annotation":"","variant":"RegulationEssential","input":"D","target":"B","value":"False","context":null}`#
+#!static_property:monotonicity_A_B:#`{"id":"monotonicity_A_B","name":"Regulation monotonicity (generated)","annotation":"","variant":"RegulationMonotonic","input":"A","target":"B","value":"Activation","context":null}`#
+#!static_property:monotonicity_A_C:#`{"id":"monotonicity_A_C","name":"Regulation monotonicity (generated)","annotation":"","variant":"RegulationMonotonic","input":"A","target":"C","value":"Activation","context":null}`#
+#!static_property:monotonicity_A_D:#`{"id":"monotonicity_A_D","name":"Regulation monotonicity (generated)","annotation":"","variant":"RegulationMonotonic","input":"A","target":"D","value":"Inhibition","context":null}`#
+#!static_property:monotonicity_B_C:#`{"id":"monotonicity_B_C","name":"Regulation monotonicity (generated)","annotation":"","variant":"RegulationMonotonic","input":"B","target":"C","value":"Dual","context":null}`#
+#!static_property:monotonicity_C_C:#`{"id":"monotonicity_C_C","name":"Regulation monotonicity (generated)","annotation":"","variant":"RegulationMonotonic","input":"C","target":"C","value":"Inhibition","context":null}`#
+#!static_property:monotonicity_D_B:#`{"id":"monotonicity_D_B","name":"Regulation monotonicity (generated)","annotation":"","variant":"RegulationMonotonic","input":"D","target":"B","value":"Dual","context":null}`#
+#!static_property:monotonicity_D_D:#`{"id":"monotonicity_D_D","name":"Regulation monotonicity (generated)","annotation":"","variant":"RegulationMonotonic","input":"D","target":"D","value":"Dual","context":null}`#
+#!variable:A:#`{"id":"A","name":"A","annotation":"","update_fn":"h(C)"}`#
+#!variable:B:#`{"id":"B","name":"B","annotation":"","update_fn":"f(A, D)"}`#
+#!variable:C:#`{"id":"C","name":"C","annotation":"","update_fn":"A & g(C, B)"}`#
+#!variable:D:#`{"id":"D","name":"D","annotation":"","update_fn":""}`#

--- a/data/test_data/test_model_various_regulations.json
+++ b/data/test_data/test_model_various_regulations.json
@@ -1,0 +1,325 @@
+{
+  "model": {
+    "variables": [
+      {
+        "id": "A",
+        "name": "A",
+        "annotation": "",
+        "update_fn": "h(C)"
+      },
+      {
+        "id": "B",
+        "name": "B",
+        "annotation": "",
+        "update_fn": "f(A, D)"
+      },
+      {
+        "id": "C",
+        "name": "C",
+        "annotation": "",
+        "update_fn": "A & g(C, B)"
+      },
+      {
+        "id": "D",
+        "name": "D",
+        "annotation": "",
+        "update_fn": ""
+      }
+    ],
+    "regulations": [
+      {
+        "regulator": "A",
+        "target": "A",
+        "sign": "Unknown",
+        "essential": "True"
+      },
+      {
+        "regulator": "A",
+        "target": "B",
+        "sign": "Activation",
+        "essential": "True"
+      },
+      {
+        "regulator": "A",
+        "target": "C",
+        "sign": "Activation",
+        "essential": "False"
+      },
+      {
+        "regulator": "A",
+        "target": "D",
+        "sign": "Inhibition",
+        "essential": "True"
+      },
+      {
+        "regulator": "B",
+        "target": "B",
+        "sign": "Unknown",
+        "essential": "Unknown"
+      },
+      {
+        "regulator": "B",
+        "target": "C",
+        "sign": "Dual",
+        "essential": "True"
+      },
+      {
+        "regulator": "C",
+        "target": "A",
+        "sign": "Unknown",
+        "essential": "False"
+      },
+      {
+        "regulator": "C",
+        "target": "C",
+        "sign": "Inhibition",
+        "essential": "False"
+      },
+      {
+        "regulator": "D",
+        "target": "B",
+        "sign": "Dual",
+        "essential": "False"
+      },
+      {
+        "regulator": "D",
+        "target": "D",
+        "sign": "Dual",
+        "essential": "Unknown"
+      }
+    ],
+    "uninterpreted_fns": [
+      {
+        "id": "f",
+        "name": "f",
+        "annotation": "",
+        "arguments": [
+          [
+            "Unknown",
+            "Unknown"
+          ],
+          [
+            "Unknown",
+            "Unknown"
+          ]
+        ],
+        "expression": ""
+      },
+      {
+        "id": "g",
+        "name": "g",
+        "annotation": "",
+        "arguments": [
+          [
+            "Unknown",
+            "Unknown"
+          ],
+          [
+            "Unknown",
+            "Unknown"
+          ]
+        ],
+        "expression": ""
+      },
+      {
+        "id": "h",
+        "name": "h",
+        "annotation": "",
+        "arguments": [
+          [
+            "Unknown",
+            "Unknown"
+          ]
+        ],
+        "expression": ""
+      }
+    ],
+    "layouts": [
+      {
+        "id": "default",
+        "name": "default",
+        "nodes": [
+          {
+            "layout": "default",
+            "variable": "A",
+            "px": 346.89832,
+            "py": 183.03789
+          },
+          {
+            "layout": "default",
+            "variable": "C",
+            "px": 504.7078,
+            "py": 101.93903
+          },
+          {
+            "layout": "default",
+            "variable": "D",
+            "px": 642.49677,
+            "py": 185.15988
+          },
+          {
+            "layout": "default",
+            "variable": "B",
+            "px": 503.0,
+            "py": 269.6
+          }
+        ]
+      }
+    ]
+  },
+  "datasets": [],
+  "dyn_properties": [],
+  "stat_properties": [
+    {
+      "id": "monotonicity_C_C",
+      "name": "Regulation monotonicity (generated)",
+      "annotation": "",
+      "variant": "RegulationMonotonic",
+      "input": "C",
+      "target": "C",
+      "value": "Inhibition",
+      "context": null
+    },
+    {
+      "id": "monotonicity_D_B",
+      "name": "Regulation monotonicity (generated)",
+      "annotation": "",
+      "variant": "RegulationMonotonic",
+      "input": "D",
+      "target": "B",
+      "value": "Dual",
+      "context": null
+    },
+    {
+      "id": "essentiality_B_C",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "B",
+      "target": "C",
+      "value": "True",
+      "context": null
+    },
+    {
+      "id": "essentiality_A_D",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "A",
+      "target": "D",
+      "value": "True",
+      "context": null
+    },
+    {
+      "id": "monotonicity_A_B",
+      "name": "Regulation monotonicity (generated)",
+      "annotation": "",
+      "variant": "RegulationMonotonic",
+      "input": "A",
+      "target": "B",
+      "value": "Activation",
+      "context": null
+    },
+    {
+      "id": "essentiality_A_A",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "A",
+      "target": "A",
+      "value": "True",
+      "context": null
+    },
+    {
+      "id": "essentiality_A_C",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "A",
+      "target": "C",
+      "value": "False",
+      "context": null
+    },
+    {
+      "id": "essentiality_A_B",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "A",
+      "target": "B",
+      "value": "True",
+      "context": null
+    },
+    {
+      "id": "essentiality_C_C",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "C",
+      "target": "C",
+      "value": "False",
+      "context": null
+    },
+    {
+      "id": "monotonicity_A_D",
+      "name": "Regulation monotonicity (generated)",
+      "annotation": "",
+      "variant": "RegulationMonotonic",
+      "input": "A",
+      "target": "D",
+      "value": "Inhibition",
+      "context": null
+    },
+    {
+      "id": "monotonicity_D_D",
+      "name": "Regulation monotonicity (generated)",
+      "annotation": "",
+      "variant": "RegulationMonotonic",
+      "input": "D",
+      "target": "D",
+      "value": "Dual",
+      "context": null
+    },
+    {
+      "id": "essentiality_C_A",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "C",
+      "target": "A",
+      "value": "False",
+      "context": null
+    },
+    {
+      "id": "monotonicity_A_C",
+      "name": "Regulation monotonicity (generated)",
+      "annotation": "",
+      "variant": "RegulationMonotonic",
+      "input": "A",
+      "target": "C",
+      "value": "Activation",
+      "context": null
+    },
+    {
+      "id": "essentiality_D_B",
+      "name": "Regulation essentiality (generated)",
+      "annotation": "",
+      "variant": "RegulationEssential",
+      "input": "D",
+      "target": "B",
+      "value": "False",
+      "context": null
+    },
+    {
+      "id": "monotonicity_B_C",
+      "name": "Regulation monotonicity (generated)",
+      "annotation": "",
+      "variant": "RegulationMonotonic",
+      "input": "B",
+      "target": "C",
+      "value": "Dual",
+      "context": null
+    }
+  ],
+  "annotation": ""
+}

--- a/src-tauri/src/app/state/mod.rs
+++ b/src-tauri/src/app/state/mod.rs
@@ -108,7 +108,7 @@ pub trait SessionHelper {
     /// This might be useful to directly mention relevant fields of more complex types.
     fn assert_payload_empty(event: &Event, component: &str) -> Result<(), DynError> {
         if event.payload.is_some() {
-            let message = format!("This event to `{component}` cannot have empty payload.");
+            let message = format!("This event to `{component}` must carry empty payload.");
             return AeonError::throw(message);
         }
         Ok(())

--- a/src-tauri/src/inference/inference_state.rs
+++ b/src-tauri/src/inference/inference_state.rs
@@ -211,7 +211,10 @@ impl InferenceState {
         self.receiver_channel = Some(progress_receiver);
         let solver = Arc::new(RwLock::new(InferenceSolver::new(progress_sender)));
         self.solver = Some(Arc::clone(&solver));
-        let sketch = self.sketch.clone();
+
+        // Process datasets in sketch, so that the variables match exactly with the model
+        // (add missing variables with unspecified values, remove extra variables)
+        let sketch = self.sketch.with_processed_datasets();
 
         // Capture only the necessary data for the async block
         let solver_clone = Arc::clone(&solver);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -183,7 +183,7 @@ fn process_aeon_action_event(payload: &str, aeon: &AeonApp, handle: &AppHandle) 
     } else {
         let result = state.consume_event(aeon, &session_id, &action);
         if let Err(e) = result {
-            // there may be better way to propagate the message to frontend
+            // There may be better way to propagate the message to frontend
             let error_message = e.to_string();
             debug!("Error processing last event: `{}`.", error_message);
             emit_error(&state, &session_id, aeon, &error_message);

--- a/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
@@ -142,7 +142,7 @@ impl Sketch {
             if !invalid_variables.is_empty() {
                 let invalid_vars_str = invalid_variables.join(", ");
                 let warning_inner =
-                    format!("Following variables are not part of the network and will be ignored for the inference: {invalid_vars_str}");
+                    format!("Following dataset variables are not part of the network and will be ignored for the inference: {invalid_vars_str}");
                 let warning = format!("> ISSUE with dataset `{dataset_id}`: {warning_inner}\n",);
                 warnings += &warning;
             }
@@ -620,7 +620,7 @@ mod tests {
             .unwrap();
         let (consistent, _, warnings) = sketch_copy.run_consistency_check();
         assert!(consistent);
-        assert!(warnings.contains("Following variables are not part of the network"));
+        assert!(warnings.contains("Following dataset variables are not part of the network"));
         assert!(warnings.contains(": C"));
 
         // Dataset missing variable B

--- a/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
@@ -621,6 +621,7 @@ mod tests {
         let (consistent, _, warnings) = sketch_copy.run_consistency_check();
         assert!(consistent);
         assert!(warnings.contains("Following variables are not part of the network"));
+        assert!(warnings.contains(": C"));
 
         // Dataset missing variable B
         let mock_obs = Observation::new_full_ones(1, "o").unwrap();
@@ -633,6 +634,7 @@ mod tests {
         let (consistent, _, warnings) = sketch_copy.run_consistency_check();
         assert!(consistent);
         assert!(warnings.contains("Following network variables are missing in the dataset"));
+        assert!(warnings.contains(": B"));
 
         // Dataset that is consistent with the model (no warnings)
         let mock_obs = Observation::new_full_ones(2, "o").unwrap();

--- a/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
@@ -104,7 +104,7 @@ impl Sketch {
             }
         }
 
-        // TODO: Maybe allow the redundant functions? We already check if these symbols are not
+        // TODO: Maybe allow the redundant unused functions? We already check if these symbols are not
         //       used in static properties, and we prune the rest later, so it should be fine.
 
         // TODO: We can consider adding a check whether update fn expressions match regulation

--- a/src-tauri/src/sketchbook/_sketch/_impl_export.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_export.rs
@@ -31,22 +31,25 @@ impl Sketch {
 
 impl Sketch {
     /// Convert the sketch instance into a customized version of AEON model format.
+    /// This format extends the standard AEON format for PSBN and layout, with additional
+    /// information present in model annotations.
     ///
-    /// This format includes the standard AEON format for PSBN and layout.
-    /// This format is compatible with other biodivine tools, but might not cover all
-    /// parts of the sketch.
-    ///
-    /// Apart from that, most remaining details of the sketch are given via model annotations.
-    /// Currently the annotations are given simpy as
+    /// This format is compatible with other biodivine tools, but the core does not
+    /// cover all parts of the sketch. The remaining parts of the sketch are given
+    /// via model annotations. Currently the annotations are given in json simply as
     ///   #!entity_type: ID: #`json_string`#
     /// These entities can be variables, functions, static/dynamic properties, and datasets.
+    ///
+    /// Note that Sketchbook supports more options for regulation monotonicity/essentiality
+    /// than the standard AEON format allows. These specialized (e.g., dual) regulations are
+    /// made unspecified in the AEON core, but provided in full as part of the annotation.
     pub fn to_aeon(&self) -> String {
-        // for standard part of aeon format, we use the transformation into aeon BN
-        // this loses some info (like new regulation types), but that is preserved via annotations
+        // For standard part of aeon format, we use the transformation into aeon BN
+        // This loses some info (specialized regulation types), but that is preserved via annotations
         let bn = self.model.to_bn();
         let mut aeon_str = bn.to_string();
 
-        // set layout info
+        // Set layout info
         let default_layout = self.model.get_default_layout();
         for (var_id, node) in default_layout.layout_nodes() {
             // write position in format #position:ID:X,Y
@@ -55,37 +58,37 @@ impl Sketch {
             aeon_str.push_str(&node_layout_str);
         }
 
-        // set the rest using aeon model annotations
+        // Set the rest using aeon model annotations
         let mut annotation = ModelAnnotation::new();
 
-        // set static properties
+        // Annotations for static properties
         for (id, stat_prop) in self.properties.stat_props() {
             let prop_data_json = StatPropertyData::from_property(id, stat_prop).to_json_str();
             annotation.ensure_value(&["static_property", id.as_str()], &prop_data_json);
         }
-        // set dynamic properties
+        // Annotations for dynamic properties
         for (id, dyn_prop) in self.properties.dyn_props() {
             let prop_data_json = DynPropertyData::from_property(id, dyn_prop).to_json_str();
             annotation.ensure_value(&["dynamic_property", id.as_str()], &prop_data_json);
         }
-        // set datasets
+        // Annotations for datasets
         for (id, dataset) in self.observations.datasets() {
             let dataset_data_json = DatasetData::from_dataset(id, dataset).to_json_str();
             annotation.ensure_value(&["dataset", id.as_str()], &dataset_data_json);
         }
-        // set variable details
+        // Annotations for variable details
         for (var_id, variable) in self.model.variables() {
             let update_fn = self.model.get_update_fn(var_id).unwrap();
             let var_data_json = VariableData::from_var(var_id, variable, update_fn).to_json_str();
             annotation.ensure_value(&["variable", var_id.as_str()], &var_data_json);
         }
-        // set function details
+        // Annotations for function details
         for (fn_id, uninterpreted_fn) in self.model.uninterpreted_fns() {
             let fn_data_json = UninterpretedFnData::from_fn(fn_id, uninterpreted_fn).to_json_str();
             annotation.ensure_value(&["function", fn_id.as_str()], &fn_data_json);
         }
 
-        // push the annotations to the aeon string
+        // Push the annotations to the aeon string
         let annotation_str = annotation.to_string();
         aeon_str.push_str(&annotation_str);
         aeon_str

--- a/src-tauri/src/sketchbook/_sketch/_impl_import.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_import.rs
@@ -41,6 +41,8 @@ impl Sketch {
     /// original BN sketches prototype format:
     ///   #!static_property: ID: #`fol_formula_string`#
     ///   #!dynamic_property: ID: #`hctl_formula_string`#
+    ///
+    /// TODO: speed up
     pub fn from_aeon(aeon_str: &str) -> Result<Sketch, String> {
         // Set basic PSBN info (variables, functions, regulations) by parsing the aeon file.
         // This also derives automatically-generated regulation properties.
@@ -299,7 +301,7 @@ impl Sketch {
     }
 
     /// Load dataset from a provided CSV file path, and add it (with provided id/name)
-    /// to this sketch.
+    /// directly to this sketch.
     pub fn load_dataset(&mut self, dataset_id: &str, csv_path: &str) -> Result<(), String> {
         // Load file contents
         let mut file = File::open(csv_path).map_err(|e| e.to_string())?;

--- a/src-tauri/src/sketchbook/_sketch/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_session_state.rs
@@ -157,7 +157,7 @@ impl SessionState for Sketch {
                 })
             } else {
                 let warning =
-                    format!("There are potential minor issues with the sketch. Consider fixing them before running the inference. \n\n{warn_message}");
+                    format!("The sketch has potential minor issues. Please review before running inference: \n\n{warn_message}");
                 Ok(Consumed::IrreversibleWithWarning {
                     state_change,
                     reset: false,

--- a/src-tauri/src/sketchbook/_sketch/_impl_sketch.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_sketch.rs
@@ -1,10 +1,12 @@
-use biodivine_lib_param_bn::symbolic_async_graph::SymbolicContext;
-
 use crate::sketchbook::data_structs::SketchData;
+use crate::sketchbook::ids::VarId;
 use crate::sketchbook::model::ModelState;
 use crate::sketchbook::observations::{Dataset, ObservationManager};
 use crate::sketchbook::properties::{DynProperty, PropertyManager, StatProperty};
 use crate::sketchbook::Sketch;
+
+use biodivine_lib_param_bn::symbolic_async_graph::SymbolicContext;
+use std::collections::HashSet;
 
 /// Utility functions for creating or modifying sketch instances.
 impl Sketch {
@@ -86,6 +88,59 @@ impl Sketch {
         self.model = ModelState::default();
         self.observations = ObservationManager::default();
         self.properties = PropertyManager::default();
+        self.annotation = String::new();
+    }
+
+    /// Get a copy of this sketch with pre-processed datasets so that they match the
+    /// model's variables.
+    ///
+    /// Any extra variables (not present in the model) are removed from all datasets,
+    /// and any missing variables (present in the model but not in the dataset) are
+    /// added with unspecified values (at the end of the dataset's variable list).
+    pub fn with_processed_datasets(&self) -> Sketch {
+        let mut modified_sketch = self.clone();
+
+        let model_variables: HashSet<&VarId> =
+            self.model.variables().map(|(var_id, _)| var_id).collect();
+        for (dataset_id, dataset) in self.observations.datasets() {
+            // Check if the variable sets match exactly first (if so, nothing to do)
+            let dataset_variables: HashSet<&VarId> = HashSet::from_iter(dataset.variables().iter());
+            if model_variables == dataset_variables {
+                continue;
+            }
+
+            let mut modified_dataset = dataset.clone();
+
+            // Remove extra variables from the dataset
+            let extra_variables = dataset_variables.difference(&model_variables);
+            for &var_id in extra_variables {
+                // Can safely unwrap, the variable ID must be valid in the dataset
+                modified_dataset.remove_var(var_id).unwrap();
+            }
+
+            // Add missing variables to the dataset (in alphabetical order for determinism)
+            let mut missing_variables = model_variables
+                .difference(&dataset_variables)
+                .collect::<Vec<_>>();
+            missing_variables.sort();
+            for &var_id in missing_variables {
+                // Place the new variable at the end of the var list
+                let new_var_idx = modified_dataset.num_variables();
+                // Can safely unwrap, the variable ID is not yet present in the dataset
+                modified_dataset
+                    .add_var_default(var_id.clone(), new_var_idx)
+                    .unwrap();
+            }
+
+            // And finally, swap the original dataset content for the modified one
+            // Can safely unwrap, the dataset ID must be valid in the sketch
+            modified_sketch
+                .observations
+                .swap_dataset_content(dataset_id, modified_dataset)
+                .unwrap();
+        }
+
+        modified_sketch
     }
 
     /// Get annotation string.
@@ -109,5 +164,68 @@ impl Sketch {
     /// Set annotation string.
     pub fn set_annotation(&mut self, annotation: &str) {
         self.annotation = annotation.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sketchbook::observations::Dataset;
+    use crate::sketchbook::Sketch;
+
+    #[test]
+    /// Test that after processing datasets, they all have matching
+    /// variables with model.
+    fn processing_dataset() {
+        // Build a simple sketch with one variables A, B, C
+        let mut sketch = Sketch::from_aeon("A -> A\nB -> B\nC -> C").unwrap();
+        assert!(sketch.assert_consistency().is_ok());
+
+        // Valid dataset with the same variables
+        let dataset1 = Dataset::new_empty("d1", vec!["A", "B", "C"]).unwrap();
+        sketch
+            .observations
+            .add_dataset_by_str("d1", dataset1)
+            .unwrap();
+
+        // Dataset referencing additional non-existing variables D and E
+        let dataset2 = Dataset::new_empty("d2", vec!["A", "B", "E", "C", "D"]).unwrap();
+        sketch
+            .observations
+            .add_dataset_by_str("d2", dataset2)
+            .unwrap();
+
+        // Dataset missing variables A and C
+        let dataset3 = Dataset::new_empty("d3", vec!["B"]).unwrap();
+        sketch
+            .observations
+            .add_dataset_by_str("d3", dataset3)
+            .unwrap();
+
+        // Dataset that is both missing variable C and has extra variable E
+        let dataset4 = Dataset::new_empty("d4", vec!["A", "B", "E"]).unwrap();
+        sketch
+            .observations
+            .add_dataset_by_str("d4", dataset4)
+            .unwrap();
+
+        let sketch_processed = sketch.with_processed_datasets();
+        assert_eq!(sketch_processed.observations.num_datasets(), 4);
+
+        let new_d1 = sketch_processed.observations.get_dataset_by_str("d1");
+        let new_d2 = sketch_processed.observations.get_dataset_by_str("d2");
+        let new_d3 = sketch_processed.observations.get_dataset_by_str("d3");
+        let new_d4 = sketch_processed.observations.get_dataset_by_str("d4");
+
+        // Datasets d1, d2, and d4 should all look like the original d1
+        // Dataset d3 should have different variable order
+        let expected_d1 = Dataset::new_empty("d1", vec!["A", "B", "C"]).unwrap();
+        let expected_d2 = Dataset::new_empty("d2", vec!["A", "B", "C"]).unwrap();
+        let expected_d3 = Dataset::new_empty("d3", vec!["B", "A", "C"]).unwrap();
+        let expected_d4 = Dataset::new_empty("d4", vec!["A", "B", "C"]).unwrap();
+
+        assert_eq!(new_d1.unwrap(), &expected_d1);
+        assert_eq!(new_d2.unwrap(), &expected_d2);
+        assert_eq!(new_d3.unwrap(), &expected_d3);
+        assert_eq!(new_d4.unwrap(), &expected_d4);
     }
 }

--- a/src-tauri/src/sketchbook/_sketch/_impl_sketch.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_sketch.rs
@@ -176,7 +176,7 @@ mod tests {
     /// Test that after processing datasets, they all have matching
     /// variables with model.
     fn processing_dataset() {
-        // Build a simple sketch with one variables A, B, C
+        // Build a simple sketch with three variables A, B, C
         let mut sketch = Sketch::from_aeon("A -> A\nB -> B\nC -> C").unwrap();
         assert!(sketch.assert_consistency().is_ok());
 

--- a/src-tauri/src/sketchbook/_tests_events/_model.rs
+++ b/src-tauri/src/sketchbook/_tests_events/_model.rs
@@ -11,7 +11,7 @@ use crate::sketchbook::model::{Essentiality, ModelState, Monotonicity};
 /// Test adding variable via events.
 fn test_add_var() {
     let variables = vec![("a", "a")];
-    let mut model = ModelState::new_from_vars(variables).unwrap();
+    let mut model = ModelState::new_with_vars(variables).unwrap();
     let model_orig = model.clone();
     assert_eq!(model.num_vars(), 1);
 
@@ -32,7 +32,7 @@ fn test_add_var() {
 /// Test removing a variable that has no regulations and its node is in default position.
 fn test_remove_var_simple() {
     let variables = vec![("a", "a_name"), ("b", "b_name")];
-    let mut model = ModelState::new_from_vars(variables).unwrap();
+    let mut model = ModelState::new_with_vars(variables).unwrap();
     let model_orig = model.clone();
 
     // test variable remove event
@@ -49,7 +49,7 @@ fn test_remove_var_simple() {
 /// Test removing a variable that has regulations and its node is in non-default position.
 fn test_remove_var_complex() {
     // make a model where var `a` is part of regulations, and its position is changed
-    let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+    let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
     let var_a = model.get_var_id("a").unwrap();
     let regulations = vec!["a -> a", "a -> b", "b -> b"];
     model.add_multiple_regulations(regulations).unwrap();
@@ -96,7 +96,7 @@ fn test_remove_var_complex() {
 /// Test setting variable's name and ID via events.
 fn test_set_var_name_id() {
     let orig_name = "a_name";
-    let mut model = ModelState::new_from_vars(vec![("a", orig_name)]).unwrap();
+    let mut model = ModelState::new_with_vars(vec![("a", orig_name)]).unwrap();
     let var_a = model.get_var_id("a").unwrap();
     let new_name = "new_name";
     let model_orig = model.clone();
@@ -126,7 +126,7 @@ fn test_set_var_name_id() {
 /// Test setting variable's update function via event.
 fn test_set_update_fn() {
     let variables = vec![("a", "a_name"), ("b", "b_name")];
-    let mut model = ModelState::new_from_vars(variables).unwrap();
+    let mut model = ModelState::new_with_vars(variables).unwrap();
     let model_orig = model.clone();
     let expression = "a => b";
     let var_a = model.get_var_id("a").unwrap();
@@ -173,7 +173,7 @@ fn test_invalid_var_events() {
 /// Test adding regulation via (raw) event.
 fn test_add_reg_simple() {
     let variables = vec![("a", "a"), ("b", "b")];
-    let mut model = ModelState::new_from_vars(variables).unwrap();
+    let mut model = ModelState::new_with_vars(variables).unwrap();
     let model_orig = model.clone();
 
     // test regulation add event
@@ -192,7 +192,7 @@ fn test_add_reg_simple() {
 /// Test changing regulation's monotonicity and essentiality via event.
 fn test_change_reg_sign_essentiality() {
     let variables = vec![("a", "a_name"), ("b", "b_name")];
-    let mut model = ModelState::new_from_vars(variables).unwrap();
+    let mut model = ModelState::new_with_vars(variables).unwrap();
     let regulations = vec!["a -> a", "a -> b", "b -> a"];
     model.add_multiple_regulations(regulations).unwrap();
     let model_orig = model.clone();
@@ -224,7 +224,7 @@ fn test_change_reg_sign_essentiality() {
 /// Test removing regulation via (raw) event.
 fn test_remove_reg_simple() {
     let variables = vec![("a", "a_name"), ("b", "b_name")];
-    let mut model = ModelState::new_from_vars(variables).unwrap();
+    let mut model = ModelState::new_with_vars(variables).unwrap();
     model.add_regulation_by_str("a -?? b").unwrap();
     let model_orig = model.clone();
 
@@ -319,7 +319,7 @@ fn test_refresh() {
     let regulations = vec!["a -> a", "b -| a", "b -| b"];
     let functions = vec![("f", "f", 2), ("g", "g", 3)];
     let expressions = ["a & !b", "!b"];
-    let mut model = ModelState::new_from_vars(variables).unwrap();
+    let mut model = ModelState::new_with_vars(variables).unwrap();
     model.add_multiple_uninterpreted_fns(functions).unwrap();
     model.add_multiple_regulations(regulations).unwrap();
 

--- a/src-tauri/src/sketchbook/layout/_layout.rs
+++ b/src-tauri/src/sketchbook/layout/_layout.rs
@@ -1,3 +1,4 @@
+use crate::sketchbook::data_structs::LayoutNodeData;
 use crate::sketchbook::ids::VarId;
 use crate::sketchbook::layout::{LayoutNode, LayoutNodeIterator, NodePosition};
 use crate::sketchbook::utils::{assert_ids_unique, assert_name_valid};
@@ -118,6 +119,22 @@ impl Layout {
             .get_mut(variable)
             .unwrap()
             .change_position(new_x, new_y);
+        Ok(())
+    }
+
+    /// Update positions of all nodes in this layout. This should not add/remove
+    /// any variables, just update their positions.
+    ///
+    /// Return `Err` if some provided variable is invalid for the network.
+    pub fn update_all_node_positions(&mut self, nodes: Vec<LayoutNodeData>) -> Result<(), String> {
+        for node in nodes {
+            let variable = VarId::new(&node.variable)?;
+            self.assert_valid_variable(&variable)?;
+            self.nodes
+                .get_mut(&variable)
+                .unwrap()
+                .change_position(node.px, node.py);
+        }
         Ok(())
     }
 

--- a/src-tauri/src/sketchbook/layout/_layout.rs
+++ b/src-tauri/src/sketchbook/layout/_layout.rs
@@ -58,7 +58,7 @@ impl Layout {
     /// variables, and all of the nodes will be located at a default position.
     ///
     /// Returns `Error` if given ids contain duplicates.
-    pub fn new_from_vars_default(name: &str, variables: Vec<VarId>) -> Result<Layout, String> {
+    pub fn new_with_vars_default(name: &str, variables: Vec<VarId>) -> Result<Layout, String> {
         let mut nodes_map = HashMap::with_capacity(variables.len());
         for var_id in &variables {
             if nodes_map
@@ -140,7 +140,9 @@ impl Layout {
     ///
     /// Return `Err` if the provided variables do not exactly match the layout variables.
     pub fn update_all_node_positions(&mut self, nodes: Vec<LayoutNodeData>) -> Result<(), String> {
-        let layout_variables = self.get_variables()?;
+        // Check if layout variables and provided variables match exactly
+        let layout_variables: HashSet<_> =
+            self.get_variables()?.iter().map(|v| v.as_str()).collect();
         let provided_variables = nodes
             .iter()
             .map(|n| n.variable.as_str())
@@ -149,9 +151,10 @@ impl Layout {
             return Err("Layout variables and provided variables must match exactly.".to_string());
         }
 
+        // Now add the nodes
         for node in nodes {
             let variable = VarId::new(&node.variable)?;
-            // We can now safely unwrap, since we checked above
+            // We can now safely unwrap, since we checked the validity of variables above
             self.nodes
                 .get_mut(&variable)
                 .unwrap()
@@ -210,8 +213,8 @@ impl Layout {
     }
 
     /// Collect variable IDs from all nodes of this layout.
-    pub fn get_variables(&self) -> Result<HashSet<&str>, String> {
-        Ok(self.nodes.keys().map(|k| k.as_str()).collect())
+    pub fn get_variables(&self) -> Result<HashSet<&VarId>, String> {
+        Ok(self.nodes.keys().collect())
     }
 
     /// Human-readable name of this layout.

--- a/src-tauri/src/sketchbook/mod.rs
+++ b/src-tauri/src/sketchbook/mod.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use std::hash::Hash;
 use std::str::FromStr;
-use utils::assert_ids_unique;
 
 /// Structs and utility methods that can be used for communication with frontend.
 pub mod data_structs;
@@ -123,6 +121,7 @@ pub trait Manager {
         T::from_str(format!("{transformed_id}_{last_index}").as_str()).unwrap()
     }
 
+    /*
     /// Check that the list of (typesafe or string) IDs contains only unique IDs (no duplicates),
     /// and check that all of the IDs are already managed by the manager instance (this is
     /// important, for instance, when we need to change already existing elements).
@@ -144,7 +143,6 @@ pub trait Manager {
         }
         Ok(())
     }
-
     /// Check that the list of (typesafe or string) IDs contains only unique IDs (no duplicates),
     /// and check that all of the IDs are NOT yet managed by the manager instance, i.e.,
     /// they are fresh new values (this is important, for instance, when we need to add several new
@@ -167,4 +165,5 @@ pub trait Manager {
         }
         Ok(())
     }
+    */
 }

--- a/src-tauri/src/sketchbook/model/_function_tree.rs
+++ b/src-tauri/src/sketchbook/model/_function_tree.rs
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     /// Test parsing of a valid update function's expression.
     fn test_valid_update_fn() {
-        let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         model
             .add_empty_uninterpreted_fn_by_str("f", "f", 1)
             .unwrap();
@@ -489,7 +489,7 @@ mod tests {
     #[test]
     /// Test parsing of several invalid update functions' expressions.
     fn test_invalid_update_fns() {
-        let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         model
             .add_empty_uninterpreted_fn_by_str("f", "f", 2)
             .unwrap();
@@ -513,7 +513,7 @@ mod tests {
     #[test]
     /// Test parsing invalid uninterpreted functions' expressions.
     fn test_invalid_uninterpreted_fn() {
-        let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         model
             .add_empty_uninterpreted_fn_by_str("f", "f", 1)
             .unwrap();
@@ -543,7 +543,7 @@ mod tests {
     #[test]
     /// Test variable & uninterpreted fn substitution.
     fn test_substitution() {
-        let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         model
             .add_empty_uninterpreted_fn_by_str("f", "f", 1)
             .unwrap();
@@ -569,7 +569,7 @@ mod tests {
     #[test]
     /// Test collecting function symbols from function's expression.
     fn test_collect_fns() {
-        let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         let fns = vec![("f", "f", 1), ("g", "g", 1), ("h", "h", 1)];
         model.add_multiple_uninterpreted_fns(fns).unwrap();
         let f = model.get_uninterpreted_fn_id("f").unwrap();
@@ -585,7 +585,7 @@ mod tests {
     /// Test collecting variables from function's expression.
     fn test_collect_vars() {
         let variables = vec![("a", "a"), ("b", "b"), ("c", "c")];
-        let mut model = ModelState::new_from_vars(variables).unwrap();
+        let mut model = ModelState::new_with_vars(variables).unwrap();
         model
             .add_empty_uninterpreted_fn_by_str("f", "f", 1)
             .unwrap();

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_convert_bn.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_convert_bn.rs
@@ -148,8 +148,6 @@ impl ModelState {
     /// Name of each variable (and parameter) used in BooleanNetwork (which should be unique) is
     /// used as both its ID and name in the resulting model. All annotations are left empty.
     /// A default layout (all nodes at 0,0) is created for the variables.
-    ///
-    /// TODO: speed up
     pub fn from_bn(bn: &BooleanNetwork) -> Result<Self, String> {
         // this collects variables and regulations
         let mut model = ModelState::from_reg_graph(bn.as_graph())?;

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_convert_bn.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_convert_bn.rs
@@ -147,7 +147,9 @@ impl ModelState {
     ///
     /// Name of each variable (and parameter) used in BooleanNetwork (which should be unique) is
     /// used as both its ID and name in the resulting model. All annotations are left empty.
-    // A default layout (all nodes at 0,0) is created for the variables.
+    /// A default layout (all nodes at 0,0) is created for the variables.
+    ///
+    /// TODO: speed up
     pub fn from_bn(bn: &BooleanNetwork) -> Result<Self, String> {
         // this collects variables and regulations
         let mut model = ModelState::from_reg_graph(bn.as_graph())?;
@@ -183,7 +185,7 @@ mod tests {
     /// - function symbol `f` of arity 2
     /// - `a` has update `(b & !a) | f(a, b)`, `b` has empty update
     fn prepare_test_model_full() -> ModelState {
-        let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         let var_a = model.get_var_id("a").unwrap();
         model
             .add_multiple_regulations(vec!["a -> b", "b -> a", "a -| a"])
@@ -224,7 +226,7 @@ mod tests {
     /// The update function for `A` should be transformed into `(B & !A) | (!A => h(B))`
     #[test]
     fn test_to_bn_with_propagated_expressions() {
-        let mut model = ModelState::new_from_vars(vec![("A", "A"), ("B", "B")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("A", "A"), ("B", "B")]).unwrap();
         model
             .add_multiple_regulations(vec!["A -> B", "B -> A", "A -| A"])
             .unwrap();

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_convert_reg_graph.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_convert_reg_graph.rs
@@ -77,16 +77,14 @@ impl ModelState {
         reg_graph
     }
 
-    /// Create a `ModelState` from the given `RegulatoryGraph` instance. The model will have
-    /// the provided variables and regulations. Name of each variable (and parameter) used
-    /// in the RegulatoryGraph (which should be unique) is used as both its ID and name in
-    /// the resulting model.
+    /// Create a `ModelState` from a given `RegulatoryGraph` instance. The model will have
+    /// the provided variables and regulations. Name of each variable (and uninterpreted fn)
+    /// used in the `RegulatoryGraph` (which should be unique) is used as both its ID and name
+    /// in the resulting `ModelState`.
     ///
-    /// All other components of the `ModelState` (update functions, uninterpreted functions,...)
-    /// are left empty. A default layout (all nodes at 0,0) is created for the variables.
-    /// Annotations are left empty.
-    ///
-    /// TODO: speed up
+    /// All other components of the `ModelState` not present in regulatory graph (update
+    /// functions, uninterpreted functions,...) are left empty. A default layout (all nodes
+    /// at origin 0,0) is created for the variables. Annotations are left empty.
     pub fn from_reg_graph(reg_graph: &RegulatoryGraph) -> Result<ModelState, String> {
         let mut model = ModelState::new_empty();
 

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_convert_reg_graph.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_convert_reg_graph.rs
@@ -86,6 +86,7 @@ impl ModelState {
     /// are left empty. A default layout (all nodes at 0,0) is created for the variables.
     /// Annotations are left empty.
     ///
+    /// TODO: speed up
     pub fn from_reg_graph(reg_graph: &RegulatoryGraph) -> Result<ModelState, String> {
         let mut model = ModelState::new_empty();
 
@@ -118,7 +119,7 @@ mod tests {
 
     /// Prepare a test model containing only variables and regulations.
     fn prepare_test_model() -> ModelState {
-        let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         model
             .add_multiple_regulations(vec!["a -> b", "b -> a", "a -| a"])
             .unwrap();

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
@@ -172,7 +172,8 @@ impl ModelState {
     }
 
     /// Add a new variable with given `var_id` and `name` to this `ModelState`. The variable
-    /// will receive a default "empty" update function.
+    /// will receive a default "empty" update function and its layout node will be crated
+    /// at a default position.
     ///
     /// The ID must be valid identifier that is not already used by some other variable.
     /// The names might be same as the ID. It also might be empty or non-unique.
@@ -788,6 +789,21 @@ impl ModelState {
         Ok(())
     }
 
+    /// Shorthand to change sign of a `Regulation` pointing from `regulator` to `target`.
+    /// Currently it basically removes the regulation, and adds a new one with the new sign.
+    ///
+    /// Returns `Err` when one of the variables is invalid
+    pub fn change_regulation_sign_by_str(
+        &mut self,
+        regulator: &str,
+        target: &str,
+        new_sign: &Monotonicity,
+    ) -> Result<(), String> {
+        let regulator_id = VarId::new(regulator)?;
+        let target_id = VarId::new(target)?;
+        self.change_regulation_sign(&regulator_id, &target_id, new_sign)
+    }
+
     /// Shorthand to change essentiality of a `Regulation` pointing from `regulator` to `target`.
     /// Currently it basically removes the regulation, and adds a new one with the new essentiality value.
     ///
@@ -808,6 +824,21 @@ impl ModelState {
             *regulation.get_sign(),
         )?;
         Ok(())
+    }
+
+    /// Shorthand to change essentiality of a `Regulation` pointing from `regulator` to `target`.
+    /// Currently it basically removes the regulation, and adds a new one with the new essentiality value.
+    ///
+    /// Returns `Err` when one of the variables is invalid.
+    pub fn change_regulation_essentiality_by_str(
+        &mut self,
+        regulator: &str,
+        target: &str,
+        new_essentiality: &Essentiality,
+    ) -> Result<(), String> {
+        let regulator_id = VarId::new(regulator)?;
+        let target_id = VarId::new(target)?;
+        self.change_regulation_essentiality(&regulator_id, &target_id, new_essentiality)
     }
 
     /// Set update function for a given variable to a provided expression.

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
@@ -1,4 +1,4 @@
-use crate::sketchbook::data_structs::ModelData;
+use crate::sketchbook::data_structs::{LayoutNodeData, ModelData};
 use crate::sketchbook::ids::{LayoutId, UninterpretedFnId, VarId};
 use crate::sketchbook::layout::Layout;
 use crate::sketchbook::model::{
@@ -933,6 +933,23 @@ impl ModelState {
             .get_mut(layout_id)
             .ok_or(format!("Error accessing layout {layout_id} in layout map"))?
             .update_node_position(var_id, px, py)
+    }
+
+    /// Update positions of ALL nodes in a given layout. This should not add/remove
+    /// any variables, just update their positions.
+    ///
+    /// Return `Err` if some provided variable is invalid for the network.
+    pub fn update_all_positions(
+        &mut self,
+        layout_id: &LayoutId,
+        nodes: Vec<LayoutNodeData>,
+    ) -> Result<(), String> {
+        self.assert_valid_layout(layout_id)?;
+
+        self.layouts
+            .get_mut(layout_id)
+            .ok_or(format!("Error accessing layout {layout_id} in layout map"))?
+            .update_all_node_positions(nodes)
     }
 
     /// **(internal)** Utility method to add a variable node to a given layout.

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_fn_expressions.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_fn_expressions.rs
@@ -262,7 +262,7 @@ mod tests {
         // - `f(x) = !x`
         // - `g(x) = unspecified`
 
-        let mut model = ModelState::new_from_vars(vec![("A", "A")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("A", "A")]).unwrap();
         let var_a = model.get_var_id("A").unwrap();
 
         model
@@ -332,7 +332,7 @@ mod tests {
         // - `h(x) = i(x) | x`
         // - `i(x) = x`
 
-        let mut model = ModelState::new_from_vars(vec![("A", "A"), ("B", "B")]).unwrap();
+        let mut model = ModelState::new_with_vars(vec![("A", "A"), ("B", "B")]).unwrap();
         model
             .add_multiple_regulations(vec!["A -?? B", "B -?? A", "B -?? B"])
             .unwrap();
@@ -345,7 +345,10 @@ mod tests {
             ])
             .unwrap();
         model
-            .set_multiple_update_fns(vec![("A", "f(B)"), ("B", "A & B")])
+            .set_update_fn(&model.get_var_id("A").unwrap(), "f(B)")
+            .unwrap();
+        model
+            .set_update_fn(&model.get_var_id("B").unwrap(), "A & B")
             .unwrap();
         model
             .set_uninterpreted_fn_expression_by_str("f", "g(var0) | var0")

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_id_generating.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_id_generating.rs
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn test_var_id_generating() {
         let model =
-            ModelState::new_from_vars(vec![("a", "name"), ("b", "name"), ("c", "name")]).unwrap();
+            ModelState::new_with_vars(vec![("a", "name"), ("b", "name"), ("c", "name")]).unwrap();
         assert_eq!(model.num_vars(), 3);
 
         // name slice that is a valid identifier as is

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
@@ -33,14 +33,6 @@ impl ModelState {
         self.regulations.len()
     }
 
-    /// Get arity of the uninterpreted function with the most arguments.
-    pub fn highest_uninterpreted_fn_arity(&self) -> usize {
-        self.uninterpreted_fns()
-            .map(|(_, x)| x.get_arity())
-            .max()
-            .unwrap_or(0)
-    }
-
     /// Check if there is a variable with given Id.
     pub fn is_valid_var_id(&self, var_id: &VarId) -> bool {
         self.variables.contains_key(var_id)

--- a/src-tauri/src/sketchbook/observations/_dataset/_impl_dataset.rs
+++ b/src-tauri/src/sketchbook/observations/_dataset/_impl_dataset.rs
@@ -146,7 +146,7 @@ impl Dataset {
     }
 
     /// Remove variable and all the values corresponding to it (decrementing dimension of the
-    /// dataset in process).
+    /// dataset in process). Essentially removes a column in the dataset table.
     pub fn remove_var(&mut self, var_id: &VarId) -> Result<(), String> {
         let idx = self.get_idx_of_var(var_id)?; // validity check inside
         self.variables.remove(idx);
@@ -587,15 +587,15 @@ mod tests {
     /// Test removing variable from a dataset.
     fn test_remove_variable() {
         let name = "dataset";
-        let obs1 = Observation::try_from_str("*1", "o").unwrap();
-        let obs2 = Observation::try_from_str("00", "p").unwrap();
-        let mut dataset = Dataset::new(name, vec![obs1, obs2], vec!["a", "b"]).unwrap();
+        let obs1 = Observation::try_from_str("*1*", "o").unwrap();
+        let obs2 = Observation::try_from_str("000", "p").unwrap();
+        let mut dataset = Dataset::new(name, vec![obs1, obs2], vec!["a", "b", "c"]).unwrap();
         dataset.remove_var_by_str("a").unwrap();
 
-        let obs1_expected = Observation::try_from_str("1", "o").unwrap();
-        let obs2_expected = Observation::try_from_str("0", "p").unwrap();
+        let obs1_expected = Observation::try_from_str("1*", "o").unwrap();
+        let obs2_expected = Observation::try_from_str("00", "p").unwrap();
         let obs_expected = vec![obs1_expected, obs2_expected];
-        let dataset_expected = Dataset::new(name, obs_expected, vec!["b"]).unwrap();
+        let dataset_expected = Dataset::new(name, obs_expected, vec!["b", "c"]).unwrap();
 
         assert_eq!(dataset, dataset_expected);
     }

--- a/src-tauri/src/sketchbook/observations/_dataset/_impl_dataset.rs
+++ b/src-tauri/src/sketchbook/observations/_dataset/_impl_dataset.rs
@@ -49,11 +49,6 @@ impl Dataset {
         Self::new(name, Vec::new(), var_names)
     }
 
-    /// Default dataset instance with no Variables or Observations, and with an empty annotation.
-    pub fn default(name: &str) -> Dataset {
-        Dataset::new_empty(name, Vec::new()).unwrap()
-    }
-
     /// Update the `annotation` property.
     pub fn with_annotation(mut self, annotation: &str) -> Self {
         self.annotation = annotation.to_string();

--- a/src-tauri/src/sketchbook/observations/_observation.rs
+++ b/src-tauri/src/sketchbook/observations/_observation.rs
@@ -28,13 +28,13 @@ impl Observation {
         })
     }
 
-    /// Update the `annotation` property.
+    /// Modifier to update the `annotation` property.
     pub fn with_annotation(mut self, annotation: &str) -> Self {
         self.annotation = annotation.to_string();
         self
     }
 
-    /// Update the `name` property.
+    /// Modifier to update the `name` property.
     pub fn with_name(mut self, name: &str) -> Self {
         self.name = name.to_string();
         self
@@ -63,7 +63,7 @@ impl Observation {
     ///
     /// Name is initialized same as ID, and annotation is empty.
     pub fn try_from_str(observation_str: &str, id: &str) -> Result<Self, String> {
-        let mut observation_vec: Vec<VarValue> = Vec::new();
+        let mut observation_vec: Vec<VarValue> = Vec::with_capacity(observation_str.len());
         for c in observation_str.chars() {
             observation_vec.push(VarValue::from_str(&c.to_string())?)
         }
@@ -105,7 +105,7 @@ impl Observation {
     /// number of values as the original observation ("arity" does not change).
     pub fn set_all_values(&mut self, values: Vec<VarValue>) -> Result<(), String> {
         if values.len() != self.num_values() {
-            return Err("Vectors of old and new values differ in length.".to_string());
+            return Err("Vectors of old and new values must have the same length.".to_string());
         }
         self.values = values;
         Ok(())
@@ -115,7 +115,7 @@ impl Observation {
     /// The new vector of values must have the same number of values as the original observation
     /// ("arity" does not change).
     pub fn set_all_values_by_str(&mut self, values: &str) -> Result<(), String> {
-        let mut converted_values: Vec<VarValue> = Vec::new();
+        let mut converted_values: Vec<VarValue> = Vec::with_capacity(values.len());
         for c in values.chars() {
             converted_values.push(VarValue::from_str(&c.to_string())?)
         }
@@ -214,7 +214,7 @@ impl Observation {
     /// Make a string with bit-encoding of values of this `Observation`.
     /// Values are encoded using characters `1`, `0`, or `*`.
     pub fn to_values_string(&self) -> String {
-        let mut values_string = String::new();
+        let mut values_string = String::with_capacity(self.num_values());
         self.values
             .iter()
             .for_each(|v| values_string.push_str(v.as_str()));

--- a/src-tauri/src/sketchbook/properties/dynamic_props/_dynamic_property.rs
+++ b/src-tauri/src/sketchbook/properties/dynamic_props/_dynamic_property.rs
@@ -311,7 +311,8 @@ impl DynProperty {
         &self.variant
     }
 
-    /// Get property's sub-field `dataset` if present. If not present, return `Err`.
+    /// Get property's sub-field `dataset`, if this kind of property has such field.
+    /// If this kind of property does not have a `dataset` field, return `Err`.
     pub fn get_dataset(&self) -> Result<Option<DatasetId>, String> {
         match &self.variant {
             DynPropertyType::ExistsFixedPoint(prop) => Ok(prop.dataset.clone()),
@@ -325,10 +326,11 @@ impl DynProperty {
         }
     }
 
-    /// Check that the property has all required fields filled out. That is just the `dataset`
-    /// in most cases at the moment.
+    /// Check that the property has all required fields filled out. For most kinds of
+    /// properties, this is just the `dataset` field in most cases at the moment.
+    ///
     /// If some of the required field is set to None, return error.
-    pub fn assert_dataset_filled(&self) -> Result<(), String> {
+    pub fn assert_required_fields_filled(&self) -> Result<(), String> {
         let missing_field_msg = "One of the required fields is not filled.";
 
         match &self.variant {

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -353,8 +353,8 @@ interface AeonState {
 
       /** DatasetData for a newly created dataset. */
       datasetCreated: Observable<DatasetData>
-      /** Create a new empty dataset. */
-      addDefaultDataset: () => void
+      /** Create a new empty dataset with variable IDs as columns. */
+      addDefaultDataset: (variable_ids: string[]) => void
       /** DatasetData for a newly loaded dataset (from a csv file).
        *  This is intentionally different than `datasetCreated`, since loaded datasets might require some processing. */
       datasetLoaded: Observable<DatasetData>
@@ -858,10 +858,10 @@ export const aeonState: AeonState = {
       observationIdChanged: new Observable<ObservationIdUpdateData>(['sketch', 'observations', 'set_obs_id']),
       observationDataChanged: new Observable<ObservationData>(['sketch', 'observations', 'set_obs_data']),
 
-      addDefaultDataset (): void {
+      addDefaultDataset (variableIds: string[]): void {
         aeonEvents.emitAction({
           path: ['sketch', 'observations', 'add_default'],
-          payload: null
+          payload: JSON.stringify(variableIds)
         })
       },
       loadDataset (path: string): void {

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -326,6 +326,12 @@ interface AeonState {
       layoutRemoved: Observable<LayoutData>
       /** Remove a layout with given ID. */
       removeLayout: (layoutId: string) => void
+      /** Collection of LayoutNodeData (with new `px` and `py`) for a modified layout.
+       * This should change exacty all nodes in the network. */
+      layoutPositionsChanged: Observable<LayoutNodeData[]>
+      /** Change a position of all variables in a layout to new coordinates.
+       * This should change exacty all nodes in the network. */
+      changeLayoutPositions: (layoutId: string, newCoordinates: LayoutNodeData[]) => void
       /** LayoutNodeData (with new `px` and `py`) for a modified layout node. */
       nodePositionChanged: Observable<LayoutNodeData>
       /** Change a position of a variable in a layout to new coordinates. */
@@ -698,6 +704,7 @@ export const aeonState: AeonState = {
 
       layoutCreated: new Observable<LayoutData>(['sketch', 'model', 'layout', 'add']),
       layoutRemoved: new Observable<LayoutData>(['sketch', 'model', 'layout', 'remove']),
+      layoutPositionsChanged: new Observable<LayoutNodeData[]>(['sketch', 'model', 'layout', 'update_all_positions']),
       nodePositionChanged: new Observable<LayoutNodeData>(['sketch', 'model', 'layout', 'update_position']),
 
       addDefaultVariable (position: LayoutNodeDataPrototype | LayoutNodeDataPrototype[] = []): void {
@@ -822,6 +829,12 @@ export const aeonState: AeonState = {
         aeonEvents.emitAction({
           path: ['sketch', 'model', 'layout', layoutId, 'remove'],
           payload: null
+        })
+      },
+      changeLayoutPositions (layoutId, newCoordinates) {
+        aeonEvents.emitAction({
+          path: ['sketch', 'model', 'layout', layoutId, 'update_all_positions'],
+          payload: JSON.stringify(newCoordinates)
         })
       },
       changeNodePosition (layoutId: string, varId: string, newX: number, newY: number): void {

--- a/src/html/component-analysis/analysis-component/analysis-component.less
+++ b/src/html/component-analysis/analysis-component/analysis-component.less
@@ -22,6 +22,23 @@
   width: 100%;
 }
 
+.header {
+  .uk-flex;
+  .uk-flex-row;
+  .uk-flex-between;
+  .uk-flex-middle;
+  .uk-box-shadow-small;
+  padding: 0.5em 1em;
+  position: sticky;
+  top: 0;
+  z-index: 99;
+}
+
+@heading-bullet-border: @text-dark;
+.header h3 {
+  color: @text-dark;
+}
+
 .results-window {
   display: flex; 
   justify-content: center; 
@@ -32,7 +49,6 @@
 .overview-message {
   text-align: center;
   margin-bottom: 20px;
-  margin-top: 20px;
   font-size: 18px;
   line-height: 25px;
 }
@@ -64,21 +80,14 @@
   margin-top: 10px;
 }
 
-.header {
-  .uk-flex;
-  .uk-flex-row;
-  .uk-flex-between;
-  .uk-flex-middle;
-  .uk-box-shadow-small;
-  padding: 0.5em 1em;
-  position: sticky;
-  top: 0;
-  z-index: 99;
-}
-
-@heading-bullet-border: @text-dark;
-.header h3 {
-  color: @text-dark;
+#inference-description {
+  text-align: center;
+  width: 540px;
+  margin: 30px 0;
+  padding: 16px;
+  border-radius: 12px;
+  font-size: 16px;
+  opacity: 0.95;
 }
 
 @media only screen and (max-width: 800px) {

--- a/src/html/component-analysis/analysis-component/analysis-component.ts
+++ b/src/html/component-analysis/analysis-component/analysis-component.ts
@@ -357,7 +357,12 @@ export default class AnalysisComponent extends LitElement {
                 Otherwise, render a button for resetting inference. -->
           ${this.selected_inference === null
 ? html`
-            <div class="uk-flex uk-flex-row uk-flex-center" style="margin-top: 90px">
+            <div class="uk-flex uk-flex-row uk-flex-center" style="margin-top: 40px">
+              <div id="inference-description" class="help-message-block uk-flex uk-flex-row uk-flex-center">
+                Ready to infer satisfying networks. The sketch is now locked for the whole computation. You can export/sample the results when complete.
+              </div>
+            </div>
+            <div class="uk-flex uk-flex-row uk-flex-center" style="margin-top: 40px">
               <button id="full-inference-button" class="uk-button uk-button-large uk-button-secondary"
                       @click="${() => {
                         this.runInference()

--- a/src/html/component-analysis/analysis-component/analysis-component.ts
+++ b/src/html/component-analysis/analysis-component/analysis-component.ts
@@ -363,7 +363,7 @@ export default class AnalysisComponent extends LitElement {
               </div>
             </div>
             <div class="uk-flex uk-flex-row uk-flex-center" style="margin-top: 40px">
-              <button id="full-inference-button" class="uk-button uk-button-large uk-button-secondary"
+              <button id="full-inference-button" class="uk-button uk-button-large uk-button-secondary uk-border-rounded"
                       @click="${() => {
                         this.runInference()
                       }}">Run full inference
@@ -374,7 +374,7 @@ export default class AnalysisComponent extends LitElement {
             <div style="height: 10px;"></div>
             
             <div class="uk-flex uk-flex-row uk-flex-center">
-              <button id="static-inference-button" class="uk-button uk-button-large uk-button-secondary"
+              <button id="static-inference-button" class="uk-button uk-button-large uk-button-secondary uk-border-rounded"
                       @click="${() => {
                         this.runStaticInference()
                       }}">Run static inference
@@ -383,7 +383,7 @@ export default class AnalysisComponent extends LitElement {
           `
 : html`
             <div class="reset-buttons">
-              <button id="reset-inference-button" class="uk-button uk-button-large uk-button-secondary"
+              <button id="reset-inference-button" class="uk-button uk-button-large uk-button-secondary uk-border-rounded"
                       @click="${() => {
                         void this.resetInference()
                       }}">Start again
@@ -399,13 +399,13 @@ export default class AnalysisComponent extends LitElement {
                 .innerHTML="${this.results !== null ? this.formatResultsOverview(this.results) : this.waitingMainMessage + '.'.repeat(this.pingCounter % 4) + '<br>'}">
               </div>
 
-              <textarea rows="12" cols="120" readonly style="text-align: left;">${this.results !== null ? this.formatResultsMetadata(this.results) : this.waitingProgressReport}</textarea>
+              <textarea class="uk-border-rounded" rows="12" cols="120" readonly style="text-align: left;">${this.results !== null ? this.formatResultsMetadata(this.results) : this.waitingProgressReport}</textarea>
 
               <!-- Conditionally render dumping/sampling sections if results are set (and there are >0 candiates) -->
               ${this.results !== null && this.results.num_sat_networks > 0
 ? html`
                 <div class="results-options uk-container">
-                  <button id="dump-bdd-button" class="uk-button uk-button-large uk-button-secondary"
+                  <button id="dump-bdd-button" class="uk-button uk-button-large uk-button-secondary uk-border-rounded"
                           @click="${async () => {
                             await this.dumpFullResults()
                           }}">Save full results
@@ -429,7 +429,7 @@ export default class AnalysisComponent extends LitElement {
                     `
 : ''}
                   </div>
-                  <button id="generate-network-button" class="uk-button uk-button-large uk-button-secondary"
+                  <button id="generate-network-button" class="uk-button uk-button-large uk-button-secondary uk-border-rounded"
                           @click="${async () => {
                             await this.sampleNetworks()
                           }}">Sample network(s)

--- a/src/html/component-editor/analysis-tab/analysis-tab.ts
+++ b/src/html/component-editor/analysis-tab/analysis-tab.ts
@@ -177,7 +177,7 @@ export class AnalysisTab extends LitElement {
               ${this.consistencyResults !== null
                   ? html`
                     <div class="results-window" style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
-                      <textarea rows="12" cols="60" readonly style="text-align: center;">${this.consistencyResults}</textarea>
+                      <textarea rows="12" cols="60" class="uk-border-rounded" readonly style="text-align: center;">${this.consistencyResults}</textarea>
                       <button class="uk-button uk-button-small uk-button-danger uk-margin-top uk-border-rounded"
                               @click="${this.closeConsistencyResults}">Close</button>
                     </div>

--- a/src/html/component-editor/analysis-tab/analysis-tab.ts
+++ b/src/html/component-editor/analysis-tab/analysis-tab.ts
@@ -139,7 +139,7 @@ export class AnalysisTab extends LitElement {
                     <td class="value">
                       ${this.numPSBNParams === null
                           ? html`
-                          <button id="compute-psbn-params-button" class="uk-button uk-button-small uk-button-secondary"
+                          <button id="compute-psbn-params-button" class="uk-button uk-button-small uk-button-secondary uk-border-rounded"
                             @click="${() => {
                               this.getPSBNParamsNum()
                             }}">Fetch
@@ -154,7 +154,7 @@ export class AnalysisTab extends LitElement {
               </table>
             </div>
             <div class="uk-flex uk-flex-row uk-flex-center">
-              <button id="open-inference-button" class="uk-button uk-button-large uk-button-secondary uk-margin-bottom"
+              <button id="open-inference-button" class="uk-button uk-button-large uk-button-secondary uk-margin-bottom uk-border-rounded"
                       @click="${() => {
                         this.runInference()
                       }}">Start inference session
@@ -166,7 +166,7 @@ export class AnalysisTab extends LitElement {
               <h3 class="uk-heading-bullet uk-margin-remove-bottom ">Consistency check</h3>
             </div>
             <div class="uk-flex uk-flex-row uk-flex-center">
-              <button id="consistency-check-button" class="uk-button uk-button-large uk-button-secondary uk-margin-bottom"
+              <button id="consistency-check-button" class="uk-button uk-button-large uk-button-secondary uk-margin-bottom uk-border-rounded"
                       @click="${() => {
                         this.checkConsistency()
                       }}">Run consistency check
@@ -178,7 +178,7 @@ export class AnalysisTab extends LitElement {
                   ? html`
                     <div class="results-window" style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
                       <textarea rows="12" cols="60" readonly style="text-align: center;">${this.consistencyResults}</textarea>
-                      <button class="uk-button uk-button-small uk-button-danger uk-margin-top"
+                      <button class="uk-button uk-button-small uk-button-danger uk-margin-top uk-border-rounded"
                               @click="${this.closeConsistencyResults}">Close</button>
                     </div>
                   `

--- a/src/html/component-editor/content-pane/content-pane.ts
+++ b/src/html/component-editor/content-pane/content-pane.ts
@@ -33,7 +33,7 @@ export default class ContentPane extends LitElement {
   protected render (): TemplateResult {
     return html`
       <div class="content-pane">
-        <button class="uk-button uk-button-small uk-button-secondary pin-button" @click="${this.pin}">
+        <button class="uk-button uk-button-small uk-button-secondary pin-button uk-border-rounded" @click="${this.pin}">
           ${this.tab.pinned ? icon(faLock).node : icon(faLockOpen).node}
         </button>
         ${this.tab.content(this.data)}

--- a/src/html/component-editor/functions-editor/functions-editor.ts
+++ b/src/html/component-editor/functions-editor/functions-editor.ts
@@ -307,7 +307,7 @@ export class FunctionsEditor extends LitElement {
             <div class="header uk-background-primary uk-margin-bottom">
               <h3 class="uk-heading-bullet uk-margin-remove-bottom">Supplementary functions</h3>
               <div class="uk-text-center">
-                <button id="add-fn-button" @click="${this.addFunction}" class="uk-button uk-button-small uk-button-primary"> + add </button>
+                <button id="add-fn-button" @click="${this.addFunction}" class="uk-button uk-button-small uk-button-primary uk-border-rounded"> + add </button>
               </div>
             </div>
             ${this.contentData?.functions.length === 0 ? html`<div class="uk-text-center uk-margin-bottom"><span class="uk-label">No functions defined</span></div>` : ''}

--- a/src/html/component-editor/observations-editor/observations-editor.ts
+++ b/src/html/component-editor/observations-editor/observations-editor.ts
@@ -176,8 +176,10 @@ export default class ObservationsEditor extends LitElement {
     }, 50)
   }
 
+  /** Create empty dataset (no observations) with network variables as columns. */
   private createDataset (): void {
-    aeonState.sketch.observations.addDefaultDataset()
+    const variableIds = this.contentData.variables.map(v => v.id)
+    aeonState.sketch.observations.addDefaultDataset(variableIds)
   }
 
   #onDatasetCreated (data: DatasetData): void {

--- a/src/html/component-editor/observations-editor/observations-editor.ts
+++ b/src/html/component-editor/observations-editor/observations-editor.ts
@@ -459,8 +459,8 @@ export default class ObservationsEditor extends LitElement {
             <div class="header uk-background-primary uk-margin-bottom">
               <h3 class="uk-heading-bullet uk-margin-remove-bottom ">Observations</h3>
               <div class="buttons-container">
-                <button @click="${this.createDataset}" class="uk-button uk-button-primary uk-button-small create-button">+ Create</button>
-                <button @click="${this.loadDataset}" class="uk-button uk-button-primary uk-button-small import-button">+ Import</button>
+                <button @click="${this.createDataset}" class="uk-button uk-button-primary uk-button-small create-button uk-border-rounded">+ Create</button>
+                <button @click="${this.loadDataset}" class="uk-button uk-button-primary uk-button-small import-button uk-border-rounded">+ Import</button>
               </div>
             </div>
             ${this.contentData?.observations.length === 0 ? html`<div class="uk-text-center"><span class="uk-label uk-margin-bottom">No observations loaded</span></div>` : ''}

--- a/src/html/component-editor/observations-editor/tabulator-utility.ts
+++ b/src/html/component-editor/observations-editor/tabulator-utility.ts
@@ -6,6 +6,7 @@ import {
   FormatModule,
   InteractionModule,
   MenuModule,
+  MoveColumnsModule,
   type Options,
   PageModule,
   ReactiveDataModule,
@@ -84,6 +85,7 @@ export const tabulatorOptions: Options = {
     column: 'index',
     dir: 'asc'
   }],
+  movableColumns: true,
   headerSort: true,
   index: 'id',
   paginationSize: 20,
@@ -110,4 +112,5 @@ export const loadTabulatorPlugins = (): void => {
   Tabulator.registerModule(MenuModule)
   Tabulator.registerModule(ResizeColumnsModule)
   Tabulator.registerModule(ReactiveDataModule)
+  Tabulator.registerModule(MoveColumnsModule)
 }

--- a/src/html/component-editor/properties-editor/properties-editor.ts
+++ b/src/html/component-editor/properties-editor/properties-editor.ts
@@ -451,7 +451,7 @@ export default class PropertiesEditor extends LitElement {
           <div class="section" id="functions">
             <div class="header uk-background-primary uk-margin-bottom">
               <h3 class="uk-heading-bullet uk-margin-remove-bottom">Static</h3>
-              <button id="add-static-property-button" class="add-property add-static-property uk-button uk-button-small uk-button-primary"
+              <button id="add-static-property-button" class="add-property add-static-property uk-button uk-button-small uk-button-primary uk-border-rounded"
                       @click="${this.openAddStaticPropertyMenu}">
                       + Add
               </button>
@@ -464,16 +464,16 @@ export default class PropertiesEditor extends LitElement {
               </div>`
 : html`
               ${this.numGeneratedRegProperties() > 0
-? html`<div class="uk-margin-small">
-                <button class="uk-button uk-button-small uk-button-primary uk-margin-bottom" @click="${this.toggleRegulationPropertiesVisibility}">
+? html`<div>
+                <button class="uk-button uk-button-small uk-button-secondary uk-margin-bottom uk-border-rounded" @click="${this.toggleRegulationPropertiesVisibility}">
                   ${this.showRegulationProperties ? 'Hide' : 'Show'} Generated Regulation Properties
                 </button>
               </div>`
 : html``}
 
               ${this.numGeneratedFnProperties() > 0
-? html`<div class="uk-margin-small">
-                <button class="uk-button uk-button-small uk-button-primary uk-margin-bottom" @click="${this.toggleFunctionPropertiesVisibility}">
+? html`<div>
+                <button class="uk-button uk-button-small uk-button-secondary uk-margin-bottom uk-border-rounded" @click="${this.toggleFunctionPropertiesVisibility}">
                   ${this.showFunctionProperties ? 'Hide' : 'Show'} Generated Function Properties
                 </button>
               </div>`
@@ -569,7 +569,7 @@ export default class PropertiesEditor extends LitElement {
           <div class="section" id="variables">
             <div class="header uk-background-primary uk-margin-bottom">
               <h3 class="uk-heading-bullet uk-margin-remove-bottom ">Dynamic</h3>
-              <button id="add-dynamic-property-button" class="add-property add-dynamic-property uk-button uk-button-small uk-button-primary"
+              <button id="add-dynamic-property-button" class="add-property add-dynamic-property uk-button uk-button-small uk-button-primary uk-border-rounded"
                       @click="${this.openAddDynamicPropertyMenu}">
                 + Add
               </button>

--- a/src/html/component-editor/regulations-editor/regulations-editor.config.ts
+++ b/src/html/component-editor/regulations-editor/regulations-editor.config.ts
@@ -40,18 +40,6 @@ export const initOptions = (container: HTMLElement): CytoscapeOptions => {
   return {
     wheelSensitivity: 0.5,
     container,
-    // Some sensible default auto-layout algorithm
-    layout: {
-      animate: true,
-      animationDuration: 300,
-      animationThreshold: 250,
-      refresh: 20,
-      fit: true,
-      name: 'cose',
-      padding: 100,
-      nodeRepulsion: () => 100000,
-      nodeDimensionsIncludeLabels: true
-    },
     boxSelectionEnabled: false,
     selectionType: 'single',
     style: [

--- a/src/html/component-editor/regulations-editor/regulations-editor.less
+++ b/src/html/component-editor/regulations-editor/regulations-editor.less
@@ -50,6 +50,20 @@
   bottom: 0;
 }
 
+#center-layout-button {
+  position: absolute;
+  z-index: 5;
+  top: 4em;
+  right: 0;
+}
+
+#cose-layout-button {
+  position: absolute;
+  z-index: 5;
+  top: 7em;
+  right: 0;
+}
+
 .input-hint {
   position: absolute;
   /* This is to accommodate longer hints */

--- a/src/html/component-editor/regulations-editor/regulations-editor.ts
+++ b/src/html/component-editor/regulations-editor/regulations-editor.ts
@@ -573,15 +573,15 @@ export class RegulationsEditor extends LitElement {
         </div>`
         )}
       </div>
-      <button id="center-layout-button" class="uk-button uk-button-small uk-button-secondary" 
+      <button id="center-layout-button" class="uk-button uk-button-small uk-button-secondary uk-border-rounded" 
         @click="${() => { this.centerFitLayout() }}">
         Center and fit
       </button>
-      <button id="cose-layout-button" class="uk-button uk-button-small uk-button-secondary" 
+      <button id="cose-layout-button" class="uk-button uk-button-small uk-button-secondary uk-border-rounded" 
         @click="${() => { this.applyCoseLayout() }}">
         Auto layout
       </button>
-      <button class="uk-button uk-button-small uk-button-secondary help-button" @mouseenter="${() => { this.showHelp = true }}" @mouseleave="${() => { this.showHelp = false }}">
+      <button class="uk-button uk-button-small uk-button-secondary help-button uk-border-rounded" @mouseenter="${() => { this.showHelp = true }}" @mouseleave="${() => { this.showHelp = false }}">
         ?
       </button>
     `

--- a/src/html/component-editor/regulations-editor/regulations-editor.ts
+++ b/src/html/component-editor/regulations-editor/regulations-editor.ts
@@ -561,7 +561,7 @@ export class RegulationsEditor extends LitElement {
       </div>
       <!-- Prepares a clean environment for the cytoscape element with a floating menu. -->
       <!-- Cytoscape editor is not part of the container above to make it always 100% of width. -->
-      <div style="width: 100%; height: 100%; position: relative;">
+      <div style="width: 100%; height: calc(100% - 3em); position: relative;">
         ${this.editorElement}
         <float-menu .type=${this.menuType} .position=${this.menuPosition} .zoom=${this.menuZoom}
                     .data=${this.menuData}></float-menu>

--- a/src/html/util/utilities.ts
+++ b/src/html/util/utilities.ts
@@ -245,15 +245,15 @@ export function getTemplateHelpText (propertyType: PropertyType): string {
     case StaticPropertyType.Generic:
       return 'A generic static property defined by the user.'
     case DynamicPropertyType.AttractorCount:
-      return 'Attractor count falls into given range.'
+      return 'Attractor count must fall into selected range.'
     case DynamicPropertyType.ExistsTrajectory:
-      return 'Observations of selected dataset lay on trajectory.'
+      return 'Observations of selected dataset must lay on trajectory.'
     case DynamicPropertyType.FixedPoint:
-      return 'Each selected observation corresponds to a fixed point.'
+      return 'Each selected observation must correspond to a fixed point.'
     case DynamicPropertyType.TrapSpace:
-      return 'Each selected observation corresponds to a trap space.'
+      return 'Each selected observation must correspond to a trap space.'
     case DynamicPropertyType.HasAttractor:
-      return 'Each selected observation exists in an attractor.'
+      return 'Each selected observation must correspond to an attractor state.'
     case DynamicPropertyType.Generic:
       return 'A generic HCTL property defined by the user.'
   }


### PR DESCRIPTION
This PR addresses multiple smaller issues, primarily related to user experience. It introduces new features for network and dataset manipulation, and refines certain aspects of the UI. A short description of the changes follows below.

Network editor:
- New auto layout algorithm for network editor, and a button to centre and fit the view on the network (#79)
- The incorrect size of the Cytoscape editor element was fixed

Dataset editor and dataset consistency:
- When adding new datasets, all network variables are added automatically as table columns
- Dataset table columns can now be dragged and moved, changing variable order easily
- Dataset variables now don't need to exactly match the model variables - there can be missing or additional variables - that way, users can only specify a subset of values without having many empty columns, or the other way around (#87)
  - A new preprocessing step is added before the inference, adding all missing variables with unspecified values, and removing all extra variables
  - Consistency check now reports the missing/extra variables as a warning only, not an error
- Consistency checking was extended with a new check to avoid empty datasets in dynamic properties, avoiding potential crashes

General, smaller UI improvements:
- New rounded style of individual buttons and other elements, updates to some margins
- Dynamic property tooltips were slightly updated
- A new message was added to the start of the inference session

Other updates focusing on performance/issues with complex constructors:
- Fixed AEON import to include information about complex regulations (e.g., dual) from annotations
- Refactored main constructors (observations, properties, model, and layout) for slightly better performance and to avoid redundant validation checks
- Cleaned some redundant `Manager` trait functionality, and similar redundant `ModelState` methods